### PR TITLE
get User-Agent from request headers

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -19,15 +19,17 @@ async def make_request(
     if MCP_TRANSPORT == "stdio":
         xoxc_token = os.environ["SLACK_XOXC_TOKEN"]
         xoxd_token = os.environ["SLACK_XOXD_TOKEN"]
+        user_agent = "MCP-Server/1.0"
     else:
         request_headers = mcp.get_context().request_context.request.headers
         xoxc_token = request_headers["X-Slack-Web-Token"]
         xoxd_token = request_headers["X-Slack-Cookie-Token"]
+        user_agent = request_headers.get("User-Agent", "MCP-Server/1.0")
 
     headers = {
         "Authorization": f"Bearer {xoxc_token}",
         "Content-Type": "application/json",
-        "User-Agent": request_headers.get("User-Agent", "MCP-Server/1.0"),
+        "User-Agent": user_agent,
     }
 
     cookies = {"d": xoxd_token}


### PR DESCRIPTION
the MCP server is getting a notification that the browser being used is no longer supported by Slack. The message encourages users to switch to a supported browser or download the Slack desktop app for the best experience. It also provides links to download the app, sign in manually, and access support resources such as FAQs and contact information. The overall purpose is to inform users about browser compatibility and guide them to continue using Slack securely and efficiently.