### PR TITLE
Enable multi-arch (amd64 + arm64) builds in Konflux pipelines

### DIFF
--- a/.tekton/slack-mcp-pull-request.yaml
+++ b/.tekton/slack-mcp-pull-request.yaml
@@ -199,10 +199,10 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - name: build-container-amd64
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -226,6 +226,53 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/amd64
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:09f012a6c726c66922703f28846a3cfa196e8a391729192cda0d8f8a757b6ff5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-container-arm64
+      params:
+      - name: IMAGE
+        value: $(params.output-image)-arm64
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/arm64
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -251,12 +298,14 @@ spec:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: ALWAYS_BUILD_INDEX
-        value: $(params.build-image-index)
+        value: "true"
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
+        - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
       runAfter:
-      - build-container
+      - build-container-amd64
+      - build-container-arm64
       taskRef:
         params:
         - name: name
@@ -418,7 +467,7 @@ spec:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -440,6 +489,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/amd64
       runAfter:
       - coverity-availability-check
       taskRef:

--- a/.tekton/slack-mcp-push.yaml
+++ b/.tekton/slack-mcp-push.yaml
@@ -196,10 +196,10 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - name: build-container-amd64
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -223,6 +223,53 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/amd64
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:09f012a6c726c66922703f28846a3cfa196e8a391729192cda0d8f8a757b6ff5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-container-arm64
+      params:
+      - name: IMAGE
+        value: $(params.output-image)-arm64
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/arm64
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -248,12 +295,14 @@ spec:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: ALWAYS_BUILD_INDEX
-        value: $(params.build-image-index)
+        value: "true"
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
+        - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
       runAfter:
-      - build-container
+      - build-container-amd64
+      - build-container-arm64
       taskRef:
         params:
         - name: name
@@ -415,7 +464,7 @@ spec:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image)-amd64
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -437,6 +486,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: PLATFORM
+        value: linux/amd64
       runAfter:
       - coverity-availability-check
       taskRef:


### PR DESCRIPTION
For our friends using macs ...

Split single build-container task into architecture-specific builds:
- build-container-amd64: builds for linux/amd64 using PLATFORM parameter
- build-container-arm64: builds for linux/arm64 using PLATFORM parameter

Updated build-image-index task to:
- Combine both amd64 and arm64 images into a multi-platform manifest
- Always build image index (ALWAYS_BUILD_INDEX: "true")
- Wait for both architecture builds to complete

Updated sast-coverity-check to use amd64 image and set PLATFORM.

Applied changes to both push and pull-request pipelines.