### PR TITLE
feat: read-only mode (SLACK_MCP_READ_ONLY / --read-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ python3 slack-mcp/scripts/setup-slack-mcp.py --refresh-tokens
 
 ---
 
+## Read-only mode
+
+For agents or automation that should **browse and search** Slack without posting, reacting, running commands, or joining channels, enable read-only mode.
+
+- **Environment variable:** set `SLACK_MCP_READ_ONLY` to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive).
+- **CLI:** pass `--read-only` when starting `slack_mcp_server.py` (equivalent to setting the variable).
+
+In read-only mode, tools that mutate Slack state (`post_message`, `send_dm`, `post_command`, `add_reaction`, `join_channel`) raise a clear error. Read tools (history, search, threads, `whoami`, channel listing, cache refresh helpers, and so on) behave as usual. Tool activity that would normally be mirrored to `LOGS_CHANNEL_ID` is written to **stderr** instead so the logs channel is not written to.
+
+On startup, the server logs a line to stderr when read-only mode is active.
+
+For Podman or Docker, add `-e SLACK_MCP_READ_ONLY=true` (and the matching key in `env`) when you want the container to run read-only.
+
 ## Running with Podman or Docker
 
 You can run the slack-mcp server in a container using Podman or Docker:

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -14,6 +14,24 @@ def log(msg: str) -> None:
     """Write diagnostic output to stderr (stdout is reserved for JSON-RPC in stdio mode)."""
     print(msg, file=sys.stderr, flush=True)
 
+
+READ_ONLY_ENV_VAR = "SLACK_MCP_READ_ONLY"
+
+
+def _is_read_only() -> bool:
+    """True when operators want browse/search only — no Slack state changes."""
+    v = os.environ.get(READ_ONLY_ENV_VAR, "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def _deny_if_read_only() -> None:
+    if _is_read_only():
+        raise RuntimeError(
+            f"This server is running in read-only mode ({READ_ONLY_ENV_VAR}). "
+            "Mutating Slack operations (post message, DM, reactions, commands, join channel) are disabled."
+        )
+
+
 SLACK_API_BASE = "https://slack.com/api"
 MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
 LOGS_CHANNEL_ID = os.environ["LOGS_CHANNEL_ID"]
@@ -79,6 +97,9 @@ async def make_request(
 
 
 async def log_to_slack(message: str):
+    if _is_read_only():
+        log(f"[read-only] {message}")
+        return
     await post_message(LOGS_CHANNEL_ID, message, skip_log=True)
 
 
@@ -507,6 +528,7 @@ async def post_message(
     channel_id: str, message: str, thread_ts: str = "", skip_log: bool = False
 ) -> bool:
     """Post a message to a channel."""
+    _deny_if_read_only()
     if not skip_log:
         await log_to_slack(f"Posting message to channel <#{channel_id}>: {message}")
     await join_channel(channel_id, skip_log=skip_log)
@@ -523,6 +545,7 @@ async def post_command(
     channel_id: str, command: str, text: str, skip_log: bool = False
 ) -> bool:
     """Post a command to a channel."""
+    _deny_if_read_only()
     if not skip_log:
         await log_to_slack(
             f"Posting command to channel <#{channel_id}>: {command} {text}"
@@ -537,6 +560,7 @@ async def post_command(
 @mcp.tool()
 async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
     """Add a reaction to a message."""
+    _deny_if_read_only()
     await log_to_slack(
         f"Adding reaction to message {message_ts} in channel <#{channel_id}>: :{reaction}:"
     )
@@ -562,6 +586,7 @@ async def whoami() -> str:
 @mcp.tool()
 async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     """Join a channel."""
+    _deny_if_read_only()
     if not skip_log:
         await log_to_slack(f"Joining channel <#{channel_id}>")
     url = f"{SLACK_API_BASE}/conversations.join"
@@ -629,6 +654,7 @@ async def list_joined_channels(
 @mcp.tool()
 async def send_dm(user_id: str, message: str) -> bool:
     """Send a direct message to a user."""
+    _deny_if_read_only()
     await log_to_slack(f"Sending direct message to user <@{user_id}>: {message}")
     url = f"{SLACK_API_BASE}/conversations.open"
     payload = {"users": user_id, "return_dm": True}
@@ -761,6 +787,14 @@ async def search_channel_messages(
 
 
 if __name__ == "__main__":
+    if "--read-only" in sys.argv:
+        os.environ[READ_ONLY_ENV_VAR] = "true"
+        sys.argv = [a for a in sys.argv if a != "--read-only"]
     # Load user cache from disk on startup
     _load_user_cache()
+    if _is_read_only():
+        log(
+            f"slack-mcp: read-only mode is active ({READ_ONLY_ENV_VAR}); "
+            "mutating Slack tools will raise errors; audit lines go to stderr only."
+        )
     mcp.run(transport=MCP_TRANSPORT)


### PR DESCRIPTION
## Summary
Adds deploy-time **read-only** mode as requested in #32.

## Behavior
- `SLACK_MCP_READ_ONLY`: truthy values `1`, `true`, `yes`, `on` (case-insensitive).
- `--read-only` CLI flag when starting `slack_mcp_server.py` (sets the env var; stripped before `mcp.run`).
- Mutating tools (`post_message`, `send_dm`, `post_command`, `add_reaction`, `join_channel`) raise `RuntimeError` with a clear message.
- `log_to_slack` writes to stderr only in read-only mode so the logs channel is not mutated.
- Startup line on stderr when read-only is active.
- README section + Podman note.

Closes #32

Made with [Cursor](https://cursor.com)