### PR TITLE
feat: add MCP tool annotations

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -3,6 +3,7 @@ import sys
 from typing import Any, Literal
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 import re
 import asyncio
 from datetime import datetime, timezone
@@ -285,7 +286,7 @@ async def get_thread_replies(channel_id: str, thread_ts: str) -> list[dict[str, 
     return messages[1:] if len(messages) > 1 else []
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_thread(
     channel_id: str,
     thread_ts: str,
@@ -327,7 +328,7 @@ async def get_thread(
     return await asyncio.gather(*[filter_message_fields(msg) for msg in messages])
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_channel_history(
     channel_id: str,
     limit: int = 1000,
@@ -453,7 +454,7 @@ async def _load_channels_to_cache() -> bool:
     return True
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_channel_id_by_name(channel_name: str) -> str:
     """Get the channel ID by channel name. The channel name can be with or without the # prefix."""
     # Remove # prefix if present
@@ -476,14 +477,14 @@ async def get_channel_id_by_name(channel_name: str) -> str:
     return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def refresh_channel_cache() -> bool:
     """Refresh the channel cache. Use this when new channels are created or if channel lookups are failing."""
     await log_to_slack("Refreshing channel cache")
     return await _load_channels_to_cache()
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def refresh_user_cache() -> int:
     """Clear the user cache. Use this when user handles are outdated or if user lookups are failing. Returns the number of cached entries cleared."""
     global _user_cache
@@ -502,7 +503,7 @@ async def refresh_user_cache() -> int:
     return count
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_message(
     channel_id: str, message: str, thread_ts: str = "", skip_log: bool = False
 ) -> bool:
@@ -518,7 +519,7 @@ async def post_message(
     return data.get("ok")
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_command(
     channel_id: str, command: str, text: str, skip_log: bool = False
 ) -> bool:
@@ -534,7 +535,7 @@ async def post_command(
     return data.get("ok")
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
     """Add a reaction to a message."""
     await log_to_slack(
@@ -550,7 +551,7 @@ async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
     return data.get("ok")
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def whoami() -> str:
     """Checks authentication & identity."""
     await log_to_slack("Checking authentication & identity")
@@ -559,7 +560,7 @@ async def whoami() -> str:
     return data.get("user")
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     """Join a channel."""
     if not skip_log:
@@ -570,7 +571,7 @@ async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     return data.get("ok")
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def list_joined_channels(
     exclude_archived: bool = True,
     limit: int = 1000,
@@ -626,7 +627,7 @@ async def list_joined_channels(
     return all_channels
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def send_dm(user_id: str, message: str) -> bool:
     """Send a direct message to a user."""
     await log_to_slack(f"Sending direct message to user <@{user_id}>: {message}")
@@ -638,7 +639,7 @@ async def send_dm(user_id: str, message: str) -> bool:
     return False
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def search_messages(
     query: str, sort: Literal["timestamp", "score"] = "timestamp", limit: int = 1000
 ) -> list[dict[str, Any] | str]:
@@ -697,7 +698,7 @@ async def search_messages(
     return await asyncio.gather(*[filter_message_fields(msg) for msg in all_matches])
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def search_channel_messages(
     channel_id: str,
     query: str,


### PR DESCRIPTION
Add standard MCP ToolAnnotations to all tools to communicate their behavior to client applications:

- readOnlyHint: True for read-only tools, False for write tools
- destructiveHint: True for irreversible operations (post_message, send_dm, post_command)
- openWorldHint: True for all tools (all make external Slack API calls, including via log_to_slack)


Assisted-by: Claude (Anthropic) <https://claude.ai>