### PR TITLE
feat: add configurable host/port and ALLOWED_HOSTS support

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -3,6 +3,7 @@ import sys
 from typing import Any, Literal
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 import re
 import asyncio
@@ -818,4 +819,13 @@ if __name__ == "__main__":
             f"slack-mcp: read-only mode is active ({READ_ONLY_ENV_VAR}); "
             "mutating Slack tools will raise errors; audit lines go to stderr only."
         )
+    if MCP_TRANSPORT != "stdio":
+        host = os.environ.get("FASTMCP_HOST", "0.0.0.0")
+        port = int(os.environ.get("FASTMCP_PORT", "8000"))
+        allowed_hosts = os.environ.get("ALLOWED_HOSTS", "")
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.settings.transport_security.allowed_hosts += [
+                h.strip() for h in allowed_hosts.split(",") if h.strip()
+        ]
     mcp.run(transport=MCP_TRANSPORT)


### PR DESCRIPTION
This change adds runtime configuration for host, port, and allowed hosts via environment variables:

- FASTMCP_HOST: bind address (default: 0.0.0.0)
- FASTMCP_PORT: port number (default: 8000)
- ALLOWED_HOSTS: comma-separated list of additional allowed Host header values (e.g. "myserver.example.com,myserver2.example.com")

When running behind a reverse proxy with a public domain name, the MCP SDK's DNS rebinding protection rejects requests because the Host header contains the external domain rather than localhost.

Rather than disabling DNS rebinding protection entirely via transport_security = None — which is a bad security practice and leaves the server vulnerable to DNS rebinding attacks — ALLOWED_HOSTS values are appended to the SDK's auto-configured defaults (127.0.0.1:*, localhost:*, [::1]:*), preserving local access while allowing external domain access.

Multiple domains are supported for servers accessible via more than one hostname.

## Testing

Tested on Fedora with nginx reverse proxy. With ALLOWED_HOSTS=myserver.example.com, external domain access works while DNS rebinding protection remains active.