### PR TITLE
feat: add ToolAnnotations to get_reactions tool

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -575,7 +575,7 @@ async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
     data = await make_request(url, payload=payload)
     return data.get("ok")
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_reactions(
     channel_id: str, message_ts: str, full: bool = True
 ) -> list[dict] | None:


### PR DESCRIPTION
Add standard MCP ToolAnnotations to the newly added get_reactions tool, consistent with all other tools in the server:

- readOnlyHint: True (read-only operation)
- openWorldHint: True (makes external Slack API call)