### PR TITLE
feat: add bot token (xoxb) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,48 @@ python3 slack-mcp/scripts/setup-slack-mcp.py --refresh-tokens
 
 ---
 
+## Bot token authentication (recommended)
+
+For better security, use a Slack App bot token (`xoxb-`) instead of browser session tokens. Bot tokens provide:
+
+- **Scoped access** — only the OAuth permissions you grant, not full user access
+- **Distinct identity** — actions appear as the bot, not as your user account
+- **Central management** — IT can audit and revoke via the Slack admin panel
+- **No browser DevTools** — tokens are generated once in the Slack App settings
+
+### Setup
+
+1. Create a Slack App at [api.slack.com/apps](https://api.slack.com/apps)
+2. Add OAuth scopes: `channels:read`, `channels:history`, `groups:read`, `groups:history`, `chat:write`, `reactions:read`, `reactions:write`, `search:read`, `users:read`, `commands`
+3. Install to your workspace and copy the Bot User OAuth Token (`xoxb-...`)
+4. Invite the bot to channels it needs access to
+
+### Running with a bot token
+
+Set `SLACK_BOT_TOKEN` instead of `SLACK_XOXC_TOKEN`/`SLACK_XOXD_TOKEN`:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "podman",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "SLACK_BOT_TOKEN",
+        "-e", "LOGS_CHANNEL_ID",
+        "quay.io/redhat-ai-tools/slack-mcp"
+      ],
+      "env": {
+        "SLACK_BOT_TOKEN": "xoxb-...",
+        "LOGS_CHANNEL_ID": "C7000000"
+      }
+    }
+  }
+}
+```
+
+If both `SLACK_BOT_TOKEN` and `SLACK_XOXC_TOKEN`/`SLACK_XOXD_TOKEN` are set, the bot token takes precedence.
+
 ## Read-only mode
 
 For agents or automation that should **browse and search** Slack without posting, reacting, running commands, or joining channels, enable read-only mode.

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -36,6 +36,7 @@ def _deny_if_read_only() -> None:
 
 SLACK_API_BASE = "https://slack.com/api"
 MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 LOGS_CHANNEL_ID = os.environ["LOGS_CHANNEL_ID"]
 OUTPUT_FORMAT = os.environ.get("OUTPUT_FORMAT", "compact").lower()
 
@@ -55,23 +56,33 @@ mcp = FastMCP("slack")
 async def make_request(
     url: str, method: str = "POST", payload: dict[str, Any] | None = None
 ) -> dict[str, Any] | None:
-    if MCP_TRANSPORT == "stdio":
+    cookies: dict[str, str] = {}
+
+    if SLACK_BOT_TOKEN:
+        headers = {
+            "Authorization": f"Bearer {SLACK_BOT_TOKEN}",
+            "Content-Type": "application/json",
+            "User-Agent": "MCP-Server/1.0",
+        }
+    elif MCP_TRANSPORT == "stdio":
         xoxc_token = os.environ["SLACK_XOXC_TOKEN"]
         xoxd_token = os.environ["SLACK_XOXD_TOKEN"]
-        user_agent = "MCP-Server/1.0"
+        headers = {
+            "Authorization": f"Bearer {xoxc_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "MCP-Server/1.0",
+        }
+        cookies = {"d": xoxd_token}
     else:
         request_headers = mcp.get_context().request_context.request.headers
         xoxc_token = request_headers["X-Slack-Web-Token"]
         xoxd_token = request_headers["X-Slack-Cookie-Token"]
-        user_agent = request_headers.get("User-Agent", "MCP-Server/1.0")
-
-    headers = {
-        "Authorization": f"Bearer {xoxc_token}",
-        "Content-Type": "application/json",
-        "User-Agent": user_agent,
-    }
-
-    cookies = {"d": xoxd_token}
+        headers = {
+            "Authorization": f"Bearer {xoxc_token}",
+            "Content-Type": "application/json",
+            "User-Agent": request_headers.get("User-Agent", "MCP-Server/1.0"),
+        }
+        cookies = {"d": xoxd_token}
 
     async with httpx.AsyncClient(cookies=cookies) as client:
         try:
@@ -814,6 +825,15 @@ if __name__ == "__main__":
         sys.argv = [a for a in sys.argv if a != "--read-only"]
     # Load user cache from disk on startup
     _load_user_cache()
+    if SLACK_BOT_TOKEN:
+        if not SLACK_BOT_TOKEN.startswith("xoxb-"):
+            log("Warning: SLACK_BOT_TOKEN does not start with xoxb- — is this a valid bot token?")
+        log("slack-mcp: using bot token authentication (scoped)")
+    elif MCP_TRANSPORT == "stdio":
+        if not os.environ.get("SLACK_XOXC_TOKEN") or not os.environ.get("SLACK_XOXD_TOKEN"):
+            log("Error: stdio mode requires SLACK_XOXC_TOKEN and SLACK_XOXD_TOKEN (or SLACK_BOT_TOKEN)")
+            sys.exit(1)
+        log("slack-mcp: using browser session token authentication (full user access)")
     if _is_read_only():
         log(
             f"slack-mcp: read-only mode is active ({READ_ONLY_ENV_VAR}); "


### PR DESCRIPTION
## Summary

- Adds `SLACK_BOT_TOKEN` as a third authentication method alongside browser session tokens (xoxc/xoxd)
- When set, bot token is used for all Slack API calls — no cookies needed
- Startup validation logs which auth method is active and warns on invalid token prefix

## Security motivation

Browser session tokens inherit full user permissions, impersonate the user in audit logs, have uncontrolled lifetime, and require DevTools extraction. Bot tokens resolve all five concerns — see #41 for the full security case.

## Changes

| File | Change |
|------|--------|
| `slack_mcp_server.py` | Add `SLACK_BOT_TOKEN` env var, three-path auth in `make_request`, startup validation in `__main__` |
| `README.md` | Bot token setup guide with OAuth scopes and Podman config example |

## Backward compatibility

No breaking changes. If `SLACK_BOT_TOKEN` is not set, behavior is identical to current code. If both bot token and xoxc/xoxd are set, bot token takes precedence.

## Test plan

- [ ] Verify existing xoxc/xoxd auth still works (no `SLACK_BOT_TOKEN` set)
- [ ] Set `SLACK_BOT_TOKEN=xoxb-...` and confirm bot auth works
- [ ] Set `SLACK_BOT_TOKEN=invalid` and confirm startup warning
- [ ] Set neither bot token nor xoxc/xoxd in stdio mode — confirm exit with error

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)