### PR TITLE
feat: add channel creation, user invitation, and group messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For better security, use a Slack App bot token (`xoxb-`) instead of browser sess
 ### Setup
 
 1. Create a Slack App at [api.slack.com/apps](https://api.slack.com/apps)
-2. Add OAuth scopes: `channels:read`, `channels:history`, `groups:read`, `groups:history`, `chat:write`, `reactions:read`, `reactions:write`, `search:read`, `users:read`, `commands`
+2. Add OAuth scopes: `channels:read`, `channels:history`, `channels:manage`, `groups:read`, `groups:history`, `groups:write`, `chat:write`, `reactions:read`, `reactions:write`, `search:read`, `users:read`, `commands`, `mpim:write`
 3. Install to your workspace and copy the Bot User OAuth Token (`xoxb-...`)
 4. Invite the bot to channels it needs access to
 

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -641,13 +641,12 @@ async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
-async def create_channel(name: str, is_private: bool = False, description: str = "") -> str | None:
+async def create_channel(name: str, is_private: bool = False) -> str | None:
     """Create a new Slack channel.
 
     Args:
         name: Channel name (will be sanitized: lowercase, hyphens, no spaces)
         is_private: Create as private channel (default: False for public)
-        description: Optional channel description/topic
 
     Returns:
         Channel ID on success, None on failure
@@ -667,8 +666,6 @@ async def create_channel(name: str, is_private: bool = False, description: str =
         "name": sanitized_name,
         "is_private": is_private
     }
-    if description:
-        payload["description"] = description
 
     data = await make_request(url, payload=payload)
 
@@ -811,7 +808,10 @@ async def send_group_dm(user_ids: list[str], message: str) -> bool:
 
     users_str = ",".join(user_ids)
     user_mentions = ", ".join([f"<@{uid}>" for uid in user_ids])
-    await log_to_slack(f"Sending group DM to {len(user_ids)} users ({user_mentions}): {message}")
+    await log_to_slack(
+        f"Sending group DM to {len(user_ids)} users ({user_mentions}) "
+        f"(message_length={len(message)})"
+    )
 
     url = f"{SLACK_API_BASE}/conversations.open"
     payload = {"users": users_str, "return_im": True}

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -640,6 +640,89 @@ async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     return data.get("ok")
 
 
+@_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
+async def create_channel(name: str, is_private: bool = False, description: str = "") -> str | None:
+    """Create a new Slack channel.
+
+    Args:
+        name: Channel name (will be sanitized: lowercase, hyphens, no spaces)
+        is_private: Create as private channel (default: False for public)
+        description: Optional channel description/topic
+
+    Returns:
+        Channel ID on success, None on failure
+    """
+    _deny_if_read_only()
+
+    sanitized_name = name.lower()
+    sanitized_name = sanitized_name.replace(" ", "-")
+    sanitized_name = re.sub(r'[^a-z0-9\-_]', '', sanitized_name)
+    sanitized_name = sanitized_name[:80]
+
+    channel_type = "private" if is_private else "public"
+    await log_to_slack(f"Creating {channel_type} channel: {sanitized_name}")
+
+    url = f"{SLACK_API_BASE}/conversations.create"
+    payload: dict[str, Any] = {
+        "name": sanitized_name,
+        "is_private": is_private
+    }
+    if description:
+        payload["description"] = description
+
+    data = await make_request(url, payload=payload)
+
+    if not data or not data.get("ok"):
+        error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
+        log(f"Error creating channel: {error_msg}")
+        return None
+
+    channel_id = data.get("channel", {}).get("id")
+    if channel_id:
+        _channel_cache[sanitized_name] = channel_id
+        log(f"Successfully created channel {sanitized_name} (ID: {channel_id})")
+
+    return channel_id
+
+
+@_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
+async def invite_users_to_channel(channel_id: str, user_ids: list[str]) -> bool:
+    """Invite multiple users to a channel.
+
+    Args:
+        channel_id: Target channel ID (C...)
+        user_ids: List of user IDs to invite (U...)
+
+    Returns:
+        True if all invitations succeeded, False otherwise
+    """
+    _deny_if_read_only()
+
+    if not user_ids:
+        log("Error: user_ids list is empty")
+        return False
+
+    users_str = ",".join(user_ids)
+    user_mentions = ", ".join([f"<@{uid}>" for uid in user_ids])
+    await log_to_slack(f"Inviting {len(user_ids)} user(s) to channel <#{channel_id}>: {user_mentions}")
+
+    url = f"{SLACK_API_BASE}/conversations.invite"
+    payload = {
+        "channel": channel_id,
+        "users": users_str
+    }
+
+    data = await make_request(url, payload=payload)
+
+    if not data or not data.get("ok"):
+        error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
+        log(f"Error inviting users to channel: {error_msg}")
+        return False
+
+    log(f"Successfully invited {len(user_ids)} user(s) to channel {channel_id}")
+    return True
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def list_joined_channels(
     exclude_archived: bool = True,
@@ -707,6 +790,44 @@ async def send_dm(user_id: str, message: str) -> bool:
     if data.get("ok"):
         return await post_message(data.get("channel").get("id"), message)
     return False
+
+
+@_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
+async def send_group_dm(user_ids: list[str], message: str) -> bool:
+    """Send a message to a group DM (multi-party direct message).
+
+    Args:
+        user_ids: List of 2+ user IDs to include in group DM
+        message: Message text to send
+
+    Returns:
+        True if message sent successfully, False otherwise
+    """
+    _deny_if_read_only()
+
+    if len(user_ids) < 2:
+        log("Error: group DM requires at least 2 users")
+        return False
+
+    users_str = ",".join(user_ids)
+    user_mentions = ", ".join([f"<@{uid}>" for uid in user_ids])
+    await log_to_slack(f"Sending group DM to {len(user_ids)} users ({user_mentions}): {message}")
+
+    url = f"{SLACK_API_BASE}/conversations.open"
+    payload = {"users": users_str, "return_im": True}
+    data = await make_request(url, payload=payload)
+
+    if not data or not data.get("ok"):
+        error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
+        log(f"Error opening group DM: {error_msg}")
+        return False
+
+    channel_id = data.get("channel", {}).get("id")
+    if not channel_id:
+        log("Error: No channel ID returned from conversations.open")
+        return False
+
+    return await post_message(channel_id, message, skip_log=True)
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))


### PR DESCRIPTION
closes #39

Adds three new MCP tools to enable complete channel and group communication workflows:                                                                      
                                                          
- **`create_channel`** - Create public or private Slack channels with automatic name sanitization                                                           
- **`invite_users_to_channel`** - Batch invite multiple users to a channel
- **`send_group_dm`** - Send multi-party direct messages (group DMs with 2+ users)   