### PR TITLE
feat: add clear_usergroup tool for clearing Slack usergroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,27 @@ A Model Context Protocol (MCP) server that enables AI assistants to interact wit
 
 ## What is this and why should I use it?
 
-This MCP server transforms your Slack workspace into an AI-accessible environment. Instead of manually switching between your AI assistant and Slack, you can now:
+This MCP server transforms your Slack workspace into an AI-accessible environment. It provides 21+ tools for comprehensive Slack interaction:
 
-- **Read channel messages** - Get real-time updates and conversation history
-- **Post messages and commands** - Send text, files, or execute Slack commands
-- **Manage reactions** - Add emoji reactions to messages
-- **Join channels** - Automatically join new channels as needed
-- **Thread conversations** - Maintain context in threaded discussions
+**Message & Thread Operations**
+- Read channel history with date filtering and thread support
+- Post messages and replies to threads
+- Search messages across workspace or within specific channels
+- Execute Slack commands
+
+**Channel Management**
+- List, join, create, and rename channels
+- Look up channel IDs by name
+- Invite users to channels
+
+**Reactions & Users**
+- Add and view emoji reactions
+- Send direct messages and group DMs
+- Manage usergroups (clear members)
+
+**Utility**
+- Check authentication status
+- Cache management for performance
 
 ### Key Benefits
 

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -822,6 +822,89 @@ async def list_joined_channels(
     return all_channels
 
 
+async def get_random_deleted_user() -> str | None:
+    """Get a random deleted user ID for clearing usergroups.
+
+    Slack API doesn't support empty usergroups, so we use a deleted user
+    as a workaround to effectively clear the usergroup.
+
+    Returns:
+        User ID of a deleted user, or None if none found
+    """
+    url = f"{SLACK_API_BASE}/users.list"
+    cursor = None
+
+    while True:
+        payload: dict[str, Any] = {"limit": 200}
+        if cursor:
+            payload["cursor"] = cursor
+
+        data = await make_request(url, method="GET", payload=payload)
+
+        if not data or not data.get("ok"):
+            log("Error fetching users list for deleted user lookup")
+            return None
+
+        for user in data.get("members", []):
+            if user.get("deleted") is True:
+                user_id = user.get("id")
+                log(f"Found deleted user: {user_id}")
+                return user_id
+
+        cursor = data.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            break
+
+    log("Could not find a deleted user for clearing usergroup")
+    return None
+
+
+@_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
+async def clear_usergroup(usergroup_id: str) -> bool:
+    """Clear all users from a Slack usergroup.
+
+    Since Slack API doesn't support empty usergroups, this uses a workaround
+    by setting the usergroup to contain only a randomly selected deleted user.
+    This effectively clears the usergroup.
+
+    Args:
+        usergroup_id: The usergroup ID (S...) to clear
+
+    Returns:
+        True if usergroup was cleared successfully, False otherwise
+    """
+    _deny_if_read_only()
+
+    await log_to_slack(f"Clearing usergroup {usergroup_id}")
+
+    # Get a deleted user to use as placeholder
+    deleted_user = await get_random_deleted_user()
+    if not deleted_user:
+        log("Failed to clear usergroup: no deleted user found")
+        return False
+
+    url = f"{SLACK_API_BASE}/usergroups.users.update"
+    payload = {
+        "usergroup": usergroup_id,
+        "users": deleted_user
+    }
+
+    data = await make_request(url, payload=payload)
+
+    if not data or not data.get("ok"):
+        # Slack can throw invalid_users error when clearing groups,
+        # but it may still clear the group successfully
+        error = data.get("error") if data else "Unknown error"
+        if error == "invalid_users":
+            log(f"Received invalid_users error but usergroup {usergroup_id} may still be cleared")
+            return True
+        log(f"Error clearing usergroup: {error}")
+        return False
+
+    log(f"Successfully cleared usergroup {usergroup_id}")
+    return True
+
+
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def send_dm(user_id: str, message: str) -> bool:
     """Send a direct message to a user."""


### PR DESCRIPTION
## Summary
- Add a new `clear_usergroup` tool that clears all users from a Slack usergroup
- Implements the workaround from [qontract-reconcile](https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/utils/slack_api.py#L289-L322) for clearing usergroups
- Since Slack API doesn't support empty usergroups, uses a deleted user as a placeholder

## Implementation Details
- `get_random_deleted_user()` helper function to find a deleted user from the workspace
- `clear_usergroup()` tool uses `usergroups.users.update` API endpoint
- Handles `invalid_users` error gracefully (Slack may still clear the group despite this error)
- Respects read-only mode via `_deny_if_read_only()`
- Logs operations to the configured Slack logs channel

## Test plan
- [ ] Test clearing a usergroup with the new tool
- [ ] Verify that the usergroup is effectively empty after clearing
- [ ] Confirm read-only mode blocks the operation
- [ ] Check error handling when no deleted users are found

## Related
Based on the implementation in app-sre/qontract-reconcile where this hack was discovered and is used in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)