### PR TITLE
fix: support Slack Enterprise Grid for create_channel

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -51,6 +51,9 @@ MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 LOGS_CHANNEL_ID = os.environ["LOGS_CHANNEL_ID"]
 OUTPUT_FORMAT = os.environ.get("OUTPUT_FORMAT", "compact").lower()
+# Required for Slack Enterprise Grid: workspace team ID (e.g. T027XXXXX).
+# Without this, conversations.create returns cannot_create_channel on org-level installs.
+SLACK_TEAM_ID = os.environ.get("SLACK_TEAM_ID", "")
 
 # Cache file path (in same directory as script)
 SCRIPT_DIR = Path(__file__).parent
@@ -666,6 +669,8 @@ async def create_channel(name: str, is_private: bool = False) -> str | None:
         "name": sanitized_name,
         "is_private": is_private
     }
+    if SLACK_TEAM_ID:
+        payload["team_id"] = SLACK_TEAM_ID
 
     data = await make_request(url, payload=payload)
 


### PR DESCRIPTION
Tested channel creation using user auth tokens failed. Updated the mcp python script with Cursor + Sonnet. 

On Enterprise Grid installs, conversations.create returns cannot_create_channel unless a team_id is provided specifying which workspace within the org to create the channel in.

Adds a SLACK_TEAM_ID env var (optional, defaults to empty string). When set, it is included in the conversations.create payload. Non-enterprise installations are unaffected since the env var defaults to empty and the conditional is never triggered.

Resolves channel creation failures on org-level Slack installs.