### PR TITLE
feat: add support for X-Slack-Bot-Token request header

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -90,14 +90,22 @@ async def make_request(
         cookies = {"d": xoxd_token}
     else:
         request_headers = mcp.get_context().request_context.request.headers
-        xoxc_token = request_headers["X-Slack-Web-Token"]
-        xoxd_token = request_headers["X-Slack-Cookie-Token"]
-        headers = {
-            "Authorization": f"Bearer {xoxc_token}",
-            "Content-Type": "application/json",
-            "User-Agent": request_headers.get("User-Agent", "MCP-Server/1.0"),
-        }
-        cookies = {"d": xoxd_token}
+        # Support either bot token or user session tokens
+        if "X-Slack-Bot-Token" in request_headers:
+            bot_token = request_headers["X-Slack-Bot-Token"]
+            headers = {
+                "Authorization": f"Bearer {bot_token}",
+                "Content-Type": "application/json",
+            }
+        else:
+            xoxc_token = request_headers["X-Slack-Web-Token"]
+            xoxd_token = request_headers["X-Slack-Cookie-Token"]
+            headers = {
+                "Authorization": f"Bearer {xoxc_token}",
+                "Content-Type": "application/json",
+                "User-Agent": request_headers.get("User-Agent", "MCP-Server/1.0"),
+            }
+            cookies = {"d": xoxd_token}
 
     async with httpx.AsyncClient(cookies=cookies) as client:
         try:


### PR DESCRIPTION
## Summary
- Add support for `X-Slack-Bot-Token` request header as an alternative to `X-Slack-Web-Token` + `X-Slack-Cookie-Token` pair
- When `X-Slack-Bot-Token` is present in request headers, use it for authentication
- Falls back to existing user session token authentication if bot token header is not provided

## Test plan
- [ ] Test with `X-Slack-Bot-Token` header
- [ ] Test fallback to `X-Slack-Web-Token` + `X-Slack-Cookie-Token` headers
- [ ] Verify both authentication methods work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)