### PR TITLE
fix: return explicit messages instead of empty values on no-match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .venv
+.user_cache.json
+.reverse_user_cache.json
+__pycache__/
+*.pyc

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -237,15 +237,16 @@ def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
     except Exception as e:
         log(f"Error saving reverse user cache: {e}")
 
-async def _fetch_all_users() -> list[dict[str, str]]:
+async def _fetch_all_users(require_email: bool = False) -> list[dict[str, str]]:
     """Fetch all workspace users via users.list with pagination. Returns simplified user records."""
     cached = _load_reverse_user_cache()
-    if cached:
+    if cached and not require_email:
         return cached
 
     url = f"{SLACK_API_BASE}/users.list"
     all_users: list[dict[str, str]] = []
     cursor = None
+    completed = False
 
     while True:
         payload: dict[str, Any] = {"limit": 200}
@@ -256,7 +257,7 @@ async def _fetch_all_users() -> list[dict[str, str]]:
         if not data or not data.get("ok"):
             error_msg = data.get("error", "Unknown error") if data else "No response"
             log(f"Error fetching users.list: {error_msg}")
-            break
+            return []
 
         for member in data.get("members", []):
             if member.get("deleted") or member.get("is_bot"):
@@ -272,9 +273,10 @@ async def _fetch_all_users() -> list[dict[str, str]]:
 
         cursor = data.get("response_metadata", {}).get("next_cursor")
         if not cursor:
+            completed = True
             break
 
-    if all_users:
+    if completed and all_users:
         _save_reverse_user_cache(all_users)
         global _user_cache
         for u in all_users:
@@ -632,13 +634,13 @@ async def resolve_user_id(query: str, max_results: int = 5) -> list[dict[str, st
     Each result contains id, handle, real_name, display_name, and email.
     """
     await log_to_slack(f"Resolving user ID for: {query}")
-    users = await _fetch_all_users()
-    if not users:
-        return []
-
     q = query.strip().lstrip("@").lower()
     if not q:
-        return []
+        return [{"id": "", "handle": "", "real_name": "No query provided", "display_name": ""}]
+
+    users = await _fetch_all_users(require_email="@" in q)
+    if not users:
+        return [{"id": "", "handle": "", "real_name": "Could not load workspace users", "display_name": ""}]
 
     exact_handle: list[dict[str, str]] = []
     exact_email: list[dict[str, str]] = []

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -237,15 +237,19 @@ def _load_reverse_user_cache() -> list[dict[str, str]]:
 
 
 def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
-    """Save the reverse user cache to disk with a timestamp."""
+    """Save the reverse user cache to disk with a timestamp.
+
+    Emails are excluded from the persisted payload to avoid storing PII on disk.
+    """
     try:
+        sanitized = [{k: v for k, v in u.items() if k != "email"} for u in users]
         data = {
             "fetched_at": datetime.now(timezone.utc).isoformat(),
-            "users": users,
+            "users": sanitized,
         }
         with open(REVERSE_USER_CACHE_FILE, 'w') as f:
             json.dump(data, f, indent=2)
-        log(f"Saved reverse user cache ({len(users)} users)")
+        log(f"Saved reverse user cache ({len(sanitized)} users)")
     except Exception as e:
         log(f"Error saving reverse user cache: {e}")
 
@@ -661,7 +665,9 @@ async def resolve_user_id(query: str) -> list[dict[str, str]]:
     if not users:
         return []
 
-    q = query.lstrip("@").lower().strip()
+    q = query.strip().lstrip("@").lower()
+    if not q:
+        return []
 
     exact_handle: list[dict[str, str]] = []
     exact_email: list[dict[str, str]] = []

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -58,6 +58,8 @@ SLACK_TEAM_ID = os.environ.get("SLACK_TEAM_ID", "")
 # Cache file path (in same directory as script)
 SCRIPT_DIR = Path(__file__).parent
 USER_CACHE_FILE = SCRIPT_DIR / ".user_cache.json"
+REVERSE_USER_CACHE_FILE = SCRIPT_DIR / ".reverse_user_cache.json"
+REVERSE_CACHE_TTL_HOURS = 24
 
 # Cache for channel name to ID mapping
 _channel_cache: dict[str, str] = {}
@@ -213,6 +215,88 @@ def _save_user_cache() -> None:
     except Exception as e:
         log(f"Error saving user cache: {e}")
 
+
+
+
+def _load_reverse_user_cache() -> list[dict[str, str]]:
+    """Load the reverse user cache from disk. Returns empty list if stale or missing."""
+    try:
+        if REVERSE_USER_CACHE_FILE.exists():
+            with open(REVERSE_USER_CACHE_FILE, 'r') as f:
+                data = json.load(f)
+            fetched_at = datetime.fromisoformat(data.get("fetched_at", "2000-01-01T00:00:00+00:00"))
+            age_hours = (datetime.now(timezone.utc) - fetched_at).total_seconds() / 3600
+            if age_hours < REVERSE_CACHE_TTL_HOURS:
+                users = data.get("users", [])
+                log(f"Loaded reverse user cache ({len(users)} users, {age_hours:.1f}h old)")
+                return users
+            log(f"Reverse user cache expired ({age_hours:.1f}h old)")
+    except Exception as e:
+        log(f"Error loading reverse user cache: {e}")
+    return []
+
+
+def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
+    """Save the reverse user cache to disk with a timestamp."""
+    try:
+        data = {
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+            "users": users,
+        }
+        with open(REVERSE_USER_CACHE_FILE, 'w') as f:
+            json.dump(data, f, indent=2)
+        log(f"Saved reverse user cache ({len(users)} users)")
+    except Exception as e:
+        log(f"Error saving reverse user cache: {e}")
+
+
+async def _fetch_all_users() -> list[dict[str, str]]:
+    """Fetch all workspace users via users.list with pagination. Returns simplified user records."""
+    cached = _load_reverse_user_cache()
+    if cached:
+        return cached
+
+    url = f"{SLACK_API_BASE}/users.list"
+    all_users: list[dict[str, str]] = []
+    cursor = None
+
+    while True:
+        payload: dict[str, Any] = {"limit": 200}
+        if cursor:
+            payload["cursor"] = cursor
+
+        data = await make_request(url, method="GET", payload=payload)
+        if not data or not data.get("ok"):
+            error_msg = data.get("error", "Unknown error") if data else "No response"
+            log(f"Error fetching users.list: {error_msg}")
+            break
+
+        for member in data.get("members", []):
+            if member.get("deleted") or member.get("is_bot"):
+                continue
+            profile = member.get("profile", {})
+            all_users.append({
+                "id": member.get("id", ""),
+                "handle": member.get("name", ""),
+                "real_name": member.get("real_name", ""),
+                "display_name": profile.get("display_name", ""),
+                "email": profile.get("email", ""),
+            })
+
+        cursor = data.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            break
+
+    if all_users:
+        _save_reverse_user_cache(all_users)
+        global _user_cache
+        for u in all_users:
+            display = u["display_name"] or u["real_name"] or u["handle"] or u["id"]
+            _user_cache[u["id"]] = display
+        _save_user_cache()
+
+    log(f"Fetched {len(all_users)} users from workspace")
+    return all_users
 
 async def get_user_handle(user_id: str) -> str:
     """Get user handle by ID with caching. Returns user_id if lookup fails."""
@@ -560,6 +644,47 @@ async def refresh_user_cache() -> int:
         log(f"Cleared {count} user cache entries but failed to delete cache file: {e}")
 
     return count
+
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True))
+async def resolve_user_id(query: str) -> list[dict[str, str]]:
+    """Resolve a Slack user ID from a name, @handle, or email address.
+
+    Searches the full workspace member list (cached for 24h).
+    Returns up to 5 matches sorted by relevance: exact handle > exact email >
+    case-insensitive name > partial substring match.
+    Each result contains id, handle, real_name, display_name, and email.
+    """
+    await log_to_slack(f"Resolving user ID for: {query}")
+    users = await _fetch_all_users()
+    if not users:
+        return []
+
+    q = query.lstrip("@").lower().strip()
+
+    exact_handle: list[dict[str, str]] = []
+    exact_email: list[dict[str, str]] = []
+    exact_name: list[dict[str, str]] = []
+    partial: list[dict[str, str]] = []
+
+    for u in users:
+        handle = u.get("handle", "").lower()
+        email = u.get("email", "").lower()
+        real = u.get("real_name", "").lower()
+        display = u.get("display_name", "").lower()
+
+        if handle == q:
+            exact_handle.append(u)
+        elif email == q or email.split("@")[0] == q:
+            exact_email.append(u)
+        elif real == q or display == q:
+            exact_name.append(u)
+        elif q in handle or q in real or q in display or q in email:
+            partial.append(u)
+
+    results = exact_handle + exact_email + exact_name + partial
+    return results[:5]
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -11,20 +11,16 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 
-
 def log(msg: str) -> None:
     """Write diagnostic output to stderr (stdout is reserved for JSON-RPC in stdio mode)."""
     print(msg, file=sys.stderr, flush=True)
 
-
 READ_ONLY_ENV_VAR = "SLACK_MCP_READ_ONLY"
-
 
 def _is_read_only() -> bool:
     """True when operators want browse/search only — no Slack state changes."""
     v = os.environ.get(READ_ONLY_ENV_VAR, "").strip().lower()
     return v in ("1", "true", "yes", "on")
-
 
 def _deny_if_read_only() -> None:
     if _is_read_only():
@@ -33,18 +29,15 @@ def _deny_if_read_only() -> None:
             "Mutating Slack operations (post message, DM, reactions, commands, join channel) are disabled."
         )
 
-
 # Process --read-only before tool registration so write tools can be excluded
 if "--read-only" in sys.argv:
     os.environ[READ_ONLY_ENV_VAR] = "true"
     sys.argv = [a for a in sys.argv if a != "--read-only"]
 
-
 def _register_tool(annotations):
     if annotations.readOnlyHint is False and _is_read_only():
         return lambda f: f
     return mcp.tool(annotations=annotations)
-
 
 SLACK_API_BASE = "https://slack.com/api"
 MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
@@ -68,7 +61,6 @@ _channel_cache: dict[str, str] = {}
 _user_cache: dict[str, str] = {}
 
 mcp = FastMCP("slack")
-
 
 async def make_request(
     url: str, method: str = "POST", payload: dict[str, Any] | None = None
@@ -133,7 +125,6 @@ async def make_request(
             log(str(e))
             return None
 
-
 async def log_to_slack(message: str):
     if _is_read_only():
         log(f"[read-only] {message}")
@@ -142,7 +133,6 @@ async def log_to_slack(message: str):
         log(message)
         return
     await post_message(LOGS_CHANNEL_ID, message, skip_log=True)
-
 
 def parse_timestamp(date_str: str, is_end_of_range: bool = False) -> str:
     """Convert various date formats to Slack Unix timestamp.
@@ -192,7 +182,6 @@ def parse_timestamp(date_str: str, is_end_of_range: bool = False) -> str:
         log(f"Error parsing date '{date_str}': {e}")
         return ""
 
-
 def _load_user_cache() -> None:
     """Load user cache from disk."""
     global _user_cache
@@ -206,7 +195,6 @@ def _load_user_cache() -> None:
         log(f"Error loading user cache: {e}")
         _user_cache = {}
 
-
 def _save_user_cache() -> None:
     """Save user cache to disk."""
     try:
@@ -214,9 +202,6 @@ def _save_user_cache() -> None:
             json.dump(_user_cache, f, indent=2)
     except Exception as e:
         log(f"Error saving user cache: {e}")
-
-
-
 
 def _load_reverse_user_cache() -> list[dict[str, str]]:
     """Load the reverse user cache from disk. Returns empty list if stale or missing."""
@@ -235,7 +220,6 @@ def _load_reverse_user_cache() -> list[dict[str, str]]:
         log(f"Error loading reverse user cache: {e}")
     return []
 
-
 def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
     """Save the reverse user cache to disk with a timestamp.
 
@@ -252,7 +236,6 @@ def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
         log(f"Saved reverse user cache ({len(sanitized)} users)")
     except Exception as e:
         log(f"Error saving reverse user cache: {e}")
-
 
 async def _fetch_all_users() -> list[dict[str, str]]:
     """Fetch all workspace users via users.list with pagination. Returns simplified user records."""
@@ -337,7 +320,6 @@ async def get_user_handle(user_id: str) -> str:
     _save_user_cache()  # Persist to disk
     return user_id
 
-
 async def replace_user_mentions(text: str) -> str:
     """Replace user ID mentions (<@USERID>) with handles (@handle)."""
     if not text:
@@ -360,7 +342,6 @@ async def replace_user_mentions(text: str) -> str:
         text = text.replace(f'<@{user_id}>', f'@{handle}')
 
     return text
-
 
 async def filter_message_fields(message: dict[str, Any]) -> dict[str, Any] | str:
     """Filter message to only essential fields to reduce token usage."""
@@ -404,7 +385,6 @@ async def filter_message_fields(message: dict[str, Any]) -> dict[str, Any] | str
             result += f" [thread:{thread_ts}]"
         return result
 
-
 # Validate and convert thread_ts if needed
 def convert_thread_ts(ts: str) -> str:
     # If ts is already in the correct format, return as is
@@ -414,7 +394,6 @@ def convert_thread_ts(ts: str) -> str:
     if re.match(r"^\d{16}$", ts):
         return f"{ts[:10]}.{ts[10:]}"
     return ""
-
 
 async def get_thread_replies(channel_id: str, thread_ts: str) -> list[dict[str, Any]]:
     """Get all replies in a thread."""
@@ -431,7 +410,6 @@ async def get_thread_replies(channel_id: str, thread_ts: str) -> list[dict[str, 
     # Returns all messages including the parent, so we skip the first one
     messages = data.get("messages", [])
     return messages[1:] if len(messages) > 1 else []
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_thread(
@@ -457,7 +435,7 @@ async def get_thread(
     if not data or not data.get("ok"):
         error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
         log(f"Error getting thread: {error_msg}")
-        return []
+        return [f"Thread not found or error: {error_msg}"]
 
     messages = data.get("messages", [])
     log(f"Retrieved {len(messages)} messages from thread {thread_ts}")
@@ -473,7 +451,6 @@ async def get_thread(
         await get_user_handle(user_id)
 
     return await asyncio.gather(*[filter_message_fields(msg) for msg in messages])
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_channel_history(
@@ -562,7 +539,6 @@ async def get_channel_history(
     # Filter messages to reduce token usage (now all users are cached)
     return await asyncio.gather(*[filter_message_fields(msg) for msg in all_messages])
 
-
 async def _load_channels_to_cache() -> bool:
     """Load all channels into the cache with pagination. Returns True if successful."""
     global _channel_cache
@@ -600,7 +576,6 @@ async def _load_channels_to_cache() -> bool:
     log(f"Loaded {len(_channel_cache)} channels into cache")
     return True
 
-
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_channel_id_by_name(channel_name: str) -> str:
     """Get the channel ID by channel name. The channel name can be with or without the # prefix."""
@@ -621,15 +596,13 @@ async def get_channel_id_by_name(channel_name: str) -> str:
             return _channel_cache[clean_name]
 
     log(f"Channel '{clean_name}' not found")
-    return ""
-
+    return f"Channel not found: {channel_name}"
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def refresh_channel_cache() -> bool:
     """Refresh the channel cache. Use this when new channels are created or if channel lookups are failing."""
     await log_to_slack("Refreshing channel cache")
     return await _load_channels_to_cache()
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def refresh_user_cache() -> int:
@@ -649,10 +622,8 @@ async def refresh_user_cache() -> int:
 
     return count
 
-
-
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True))
-async def resolve_user_id(query: str) -> list[dict[str, str]]:
+async def resolve_user_id(query: str, max_results: int = 5) -> list[dict[str, str]]:
     """Resolve a Slack user ID from a name, @handle, or email address.
 
     Searches the full workspace member list (cached for 24h).
@@ -690,8 +661,9 @@ async def resolve_user_id(query: str) -> list[dict[str, str]]:
             partial.append(u)
 
     results = exact_handle + exact_email + exact_name + partial
-    return results[:5]
-
+    if not results:
+        return [{"id": "", "handle": "", "real_name": f"No matches found for: {query}", "display_name": ""}]
+    return results[:max_results]
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_message(
@@ -709,7 +681,6 @@ async def post_message(
     data = await make_request(url, payload=payload)
     return data.get("ok")
 
-
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_command(
     channel_id: str, command: str, text: str, skip_log: bool = False
@@ -725,7 +696,6 @@ async def post_command(
     payload = {"channel": channel_id, "command": command, "text": text}
     data = await make_request(url, payload=payload)
     return data.get("ok")
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
@@ -760,9 +730,12 @@ async def get_reactions(
     data = await make_request(url, method="GET", payload=payload)
     if data and data.get("ok"):
         message = data.get("message", {})
-        return message.get("reactions", [])
-    return None
-
+        reactions = message.get("reactions", [])
+        if not reactions:
+            return [{"name": "none", "count": 0, "users": ["No reactions on this message"]}]
+        return reactions
+    error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
+    return [{"name": "error", "count": 0, "users": [f"Could not fetch reactions: {error_msg}"]}]
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def whoami() -> str:
@@ -771,7 +744,6 @@ async def whoami() -> str:
     url = f"{SLACK_API_BASE}/auth.test"
     data = await make_request(url)
     return data.get("user")
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
@@ -783,7 +755,6 @@ async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     payload = {"channel": channel_id}
     data = await make_request(url, payload=payload)
     return data.get("ok")
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def create_channel(name: str, is_private: bool = False) -> str | None:
@@ -828,7 +799,6 @@ async def create_channel(name: str, is_private: bool = False) -> str | None:
 
     return channel_id
 
-
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def invite_users_to_channel(channel_id: str, user_ids: list[str]) -> bool:
     """Invite multiple users to a channel.
@@ -865,7 +835,6 @@ async def invite_users_to_channel(channel_id: str, user_ids: list[str]) -> bool:
 
     log(f"Successfully invited {len(user_ids)} user(s) to channel {channel_id}")
     return True
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def rename_channel(channel_id: str, new_name: str) -> bool:
@@ -911,7 +880,6 @@ async def rename_channel(channel_id: str, new_name: str) -> bool:
     _channel_cache[actual_name] = channel_id
 
     return True
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def list_joined_channels(
@@ -968,7 +936,6 @@ async def list_joined_channels(
     print(f"Listed {len(all_channels)} joined channels")
     return all_channels
 
-
 async def get_random_deleted_user() -> str | None:
     """Get a random deleted user ID for clearing usergroups.
 
@@ -1004,7 +971,6 @@ async def get_random_deleted_user() -> str | None:
 
     log("Could not find a deleted user for clearing usergroup")
     return None
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def clear_usergroup(usergroup_id: str) -> bool:
@@ -1051,7 +1017,6 @@ async def clear_usergroup(usergroup_id: str) -> bool:
     log(f"Successfully cleared usergroup {usergroup_id}")
     return True
 
-
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def send_dm(user_id: str, message: str) -> bool:
     """Send a direct message to a user."""
@@ -1063,7 +1028,6 @@ async def send_dm(user_id: str, message: str) -> bool:
     if data.get("ok"):
         return await post_message(data.get("channel").get("id"), message)
     return False
-
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def send_group_dm(user_ids: list[str], message: str) -> bool:
@@ -1104,7 +1068,6 @@ async def send_group_dm(user_ids: list[str], message: str) -> bool:
         return False
 
     return await post_message(channel_id, message, skip_log=True)
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def search_messages(
@@ -1163,7 +1126,6 @@ async def search_messages(
 
     # Filter messages to reduce token usage (now all users are cached)
     return await asyncio.gather(*[filter_message_fields(msg) for msg in all_matches])
-
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def search_channel_messages(
@@ -1226,7 +1188,6 @@ async def search_channel_messages(
         await get_user_handle(user_id)
 
     return await asyncio.gather(*[filter_message_fields(msg) for msg in all_matches])
-
 
 if __name__ == "__main__":
     _load_user_cache()


### PR DESCRIPTION
## Summary
- Tools returning empty lists/strings (`[]`, `""`, `None`) caused Cursor to display "(omitted)" to the agent, which confused it into retrying the call instead of understanding that no results were found.
- This PR makes four read-only tools return explicit descriptive messages when they have no data, so agents always get a clear signal.
## Changes
| Tool | Before (no match) | After (no match) |
|------|-------------------|------------------|
| `resolve_user_id` | `[]` → "(omitted)" | `[{"real_name": "No matches found for: query", ...}]` |
| `get_channel_id_by_name` | `""` → "(omitted)" | `"Channel not found: {name}"` |
| `get_thread` | `[]` → "(omitted)" | `["Thread not found or error: {msg}"]` |
| `get_reactions` | `None` → "(omitted)" | `[{"name": "error", "users": ["Could not fetch reactions: {msg}"]}]` |
## Test plan
- [x] `resolve_user_id` with unknown user returns explicit message
- [x] `get_channel_id_by_name` with unknown channel returns explicit message
- [x] `get_thread` with invalid channel/ts returns explicit error
- [x] `get_reactions` with invalid channel/ts returns explicit error
- [x] All tools still return normal data when matches are found