### PR TITLE
fix: use log() instead of print() to avoid polluting stdio JSON-RPC stream

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -945,7 +945,7 @@ async def list_joined_channels(
 
         if not data or not data.get("ok"):
             error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
-            print(f"Error listing joined channels: {error_msg}")
+            log(f"Error listing joined channels: {error_msg}")
             break
 
         for ch in data.get("channels", []):
@@ -965,7 +965,7 @@ async def list_joined_channels(
         if not cursor:
             break
 
-    print(f"Listed {len(all_channels)} joined channels")
+    log(f"Listed {len(all_channels)} joined channels")
     return all_channels
 
 
@@ -1201,7 +1201,7 @@ async def search_channel_messages(
 
         if not data or not data.get("ok"):
             error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
-            print(f"Error searching channel messages: {error_msg}")
+            log(f"Error searching channel messages: {error_msg}")
             break
 
         messages_data = data.get("messages", {})
@@ -1214,7 +1214,7 @@ async def search_channel_messages(
 
         page += 1
 
-    print(f"Retrieved {len(all_matches)} search results for query in channel {channel_id}")
+    log(f"Retrieved {len(all_matches)} search results for query in channel {channel_id}")
 
     unique_users = {msg.get("user") for msg in all_matches if msg.get("user")}
     mention_pattern = r'<@([A-Z0-9]+)>'


### PR DESCRIPTION
## Summary

- Four `print()` calls in `list_joined_channels` and `search_channel_messages` write diagnostic messages to **stdout**, which is reserved for JSON-RPC in stdio transport mode.
- This causes MCP clients (e.g. Cursor, Claude Code) to fail with `Unexpected token 'R', "Retrieved "... is not valid JSON` when these tools are invoked, and poisons the stdout stream so subsequent reconnect attempts also fail.
- Fix: replace all four bare `print()` calls with `log()`, which correctly writes to **stderr**.

## Affected lines

| Line | Function | Message |
|------|----------|---------|
| 948 | `list_joined_channels` | `Error listing joined channels: ...` |
| 968 | `list_joined_channels` | `Listed N joined channels` |
| 1204 | `search_channel_messages` | `Error searching channel messages: ...` |
| 1217 | `search_channel_messages` | `Retrieved N search results...` |

## Root cause

The `log()` helper (line 15) correctly sends diagnostics to `sys.stderr`. These four calls used bare `print()` instead, which defaults to `sys.stdout`. In stdio MCP transport, stdout is the JSON-RPC channel — any non-JSON output breaks the protocol.

## Test plan

- [x] Verified no remaining bare `print()` calls (only `log()` function itself uses `print(..., file=sys.stderr)`)
- [ ] Run `search_channel_messages` and `list_joined_channels` via stdio transport and confirm no stdout pollution