### PR TITLE
feat: Block Kit support, unfurl controls, and robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .venv
+.user_cache.json
+.reverse_user_cache.json
+__pycache__/
+*.pyc

--- a/scripts/slack-refresh-tokens
+++ b/scripts/slack-refresh-tokens
@@ -23,27 +23,36 @@
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
-SLACK_DIR="${HOME}/.config/Slack"
 OUTPUT_FILE="${HOME}/.local/share/slack-mcp/tokens.env"
 VALIDATE=false
 ENV_MODE=false
+
+# Auto-detect Slack installation: Flatpak or native
+if [[ -d "${HOME}/.var/app/com.slack.Slack/config/Slack" ]]; then
+  SLACK_DIR="${HOME}/.var/app/com.slack.Slack/config/Slack"
+elif [[ -d "${HOME}/.config/Slack" ]]; then
+  SLACK_DIR="${HOME}/.config/Slack"
+else
+  SLACK_DIR=""
+fi
 
 usage() {
   cat <<EOF
 Usage: $SCRIPT_NAME [OPTIONS]
 
 Extract Slack session tokens from the desktop app's local storage.
+Supports both native and Flatpak installations (auto-detected).
 
 Options:
   --validate    Validate tokens against Slack's auth.test API after extraction
   --env         Print tokens as shell environment variables to stdout (no file write)
   --output FILE Write tokens to FILE instead of the default ($OUTPUT_FILE)
+  --slack-dir D Override auto-detected Slack data directory
   --help        Show this help
 
 Requirements:
   - Slack desktop app installed and signed in
-  - python3 with cryptography package (pip install cryptography)
-  - secret-tool (part of libsecret-tools / gnome-keyring)
+  - python3 with cryptography and secretstorage packages
   - curl and jq (for --validate)
 
 EOF
@@ -55,17 +64,21 @@ while [[ $# -gt 0 ]]; do
     --validate)  VALIDATE=true; shift ;;
     --env)       ENV_MODE=true; shift ;;
     --output)    OUTPUT_FILE="$2"; shift 2 ;;
+    --slack-dir) SLACK_DIR="$2"; shift 2 ;;
     --help|-h)   usage ;;
     *)           echo "Unknown option: $1" >&2; exit 2 ;;
   esac
 done
 
 # --- Preflight checks ---
-if [[ ! -d "$SLACK_DIR" ]]; then
-  echo "ERROR: Slack desktop app not found at $SLACK_DIR" >&2
-  echo "Install it from https://slack.com/downloads/linux" >&2
+if [[ -z "$SLACK_DIR" || ! -d "$SLACK_DIR" ]]; then
+  echo "ERROR: Slack desktop app not found." >&2
+  echo "Checked: ~/.config/Slack (native) and ~/.var/app/com.slack.Slack/config/Slack (Flatpak)" >&2
+  echo "Install Slack or use --slack-dir to specify the location." >&2
   exit 1
 fi
+
+echo "Using Slack data directory: $SLACK_DIR"
 
 if [[ ! -f "$SLACK_DIR/Cookies" ]]; then
   echo "ERROR: No Cookies database — is the Slack app signed in?" >&2
@@ -83,29 +96,42 @@ if ! python3 -c "from cryptography.hazmat.primitives.ciphers import Cipher" 2>/d
   exit 1
 fi
 
-if ! command -v secret-tool &>/dev/null; then
-  echo "ERROR: secret-tool not found (part of libsecret-tools)" >&2
-  echo "Install it: sudo dnf install libsecret" >&2
+if ! python3 -c "import secretstorage" 2>/dev/null; then
+  echo "ERROR: python3 secretstorage package not found" >&2
+  echo "Install it: pip install secretstorage" >&2
   exit 1
 fi
 
 # --- Extract tokens ---
 tokens=$(python3 -c "
-import sqlite3, os, hashlib, subprocess, sys
+import sqlite3, os, hashlib, sys
+import secretstorage
 
 slack_dir = '$SLACK_DIR'
 
-# --- xoxd: decrypt from Cookies SQLite ---
-keyring_pass = subprocess.run(
-    ['secret-tool', 'lookup', 'application', 'Slack'],
-    capture_output=True, text=True
-).stdout.strip()
+# --- Get encryption key from system keyring ---
+# Supports both native ('application'='Slack') and Flatpak
+# ('server'='Slack Keys', 'user'='Slack Safe Storage') keyring entries.
+bus = secretstorage.dbus_init()
+keyring_pass = None
+for coll in secretstorage.get_all_collections(bus):
+    for item in coll.get_all_items():
+        attrs = item.get_attributes()
+        if attrs.get('application') == 'Slack':
+            keyring_pass = item.get_secret().decode()
+            break
+        if attrs.get('user') == 'Slack Safe Storage' and attrs.get('server') == 'Slack Keys':
+            keyring_pass = item.get_secret().decode()
+            break
+    if keyring_pass:
+        break
 
 if not keyring_pass:
-    print('ERROR: No Slack encryption key in GNOME Keyring.', file=sys.stderr)
+    print('ERROR: No Slack encryption key in system keyring.', file=sys.stderr)
     print('Is the Slack desktop app signed in?', file=sys.stderr)
     sys.exit(1)
 
+# --- xoxd: decrypt from Cookies SQLite ---
 key = hashlib.pbkdf2_hmac('sha1', keyring_pass.encode(), b'saltysalt', 1, dklen=16)
 
 conn = sqlite3.connect(os.path.join(slack_dir, 'Cookies'))
@@ -133,22 +159,26 @@ if idx < 0:
     sys.exit(1)
 xoxd = text[idx:]
 
-# --- xoxc: scan leveldb ---
+# --- xoxc: scan leveldb (newest files first for freshest token) ---
 ldb_dir = os.path.join(slack_dir, 'Local Storage', 'leveldb')
 xoxc = None
-for f in sorted(os.listdir(ldb_dir)):
-    if f.endswith('.log') or f.endswith('.ldb'):
-        try:
-            data = open(os.path.join(ldb_dir, f), 'rb').read()
-            i = data.find(b'xoxc-')
-            if i >= 0:
-                end = i
-                while end < len(data) and data[end:end+1] not in (b'\"', b' ', b'\n', b'\x00', b'\t'):
-                    end += 1
-                xoxc = data[i:end].decode('utf-8', errors='replace')
-                break
-        except Exception:
-            pass
+files = sorted(
+    [f for f in os.listdir(ldb_dir) if f.endswith('.log') or f.endswith('.ldb')],
+    key=lambda f: os.path.getmtime(os.path.join(ldb_dir, f)),
+    reverse=True
+)
+for f in files:
+    try:
+        data = open(os.path.join(ldb_dir, f), 'rb').read()
+        i = data.find(b'xoxc-')
+        if i >= 0:
+            end = i
+            while end < len(data) and data[end:end+1] not in (b'\"', b' ', b'\n', b'\x00', b'\t'):
+                end += 1
+            xoxc = data[i:end].decode('utf-8', errors='replace')
+            break
+    except Exception:
+        pass
 
 if not xoxc:
     print('ERROR: xoxc token not found in Slack Local Storage.', file=sys.stderr)

--- a/scripts/slack-refresh-tokens
+++ b/scripts/slack-refresh-tokens
@@ -103,11 +103,12 @@ if ! python3 -c "import secretstorage" 2>/dev/null; then
 fi
 
 # --- Extract tokens ---
+export SLACK_DIR
 tokens=$(python3 -c "
 import sqlite3, os, hashlib, sys
 import secretstorage
 
-slack_dir = '$SLACK_DIR'
+slack_dir = os.environ['SLACK_DIR']
 
 # --- Get encryption key from system keyring ---
 # Supports both native ('application'='Slack') and Flatpak

--- a/scripts/slack-refresh-tokens
+++ b/scripts/slack-refresh-tokens
@@ -168,9 +168,15 @@ xoxd = text[idx:]
 # --- xoxc: scan leveldb (newest files first for freshest token) ---
 ldb_dir = os.path.join(slack_dir, 'Local Storage', 'leveldb')
 xoxc = None
+def _mtime(f):
+    try:
+        return os.path.getmtime(os.path.join(ldb_dir, f))
+    except OSError:
+        return -1
+
 files = sorted(
     [f for f in os.listdir(ldb_dir) if f.endswith('.log') or f.endswith('.ldb')],
-    key=lambda f: os.path.getmtime(os.path.join(ldb_dir, f)),
+    key=_mtime,
     reverse=True
 )
 for f in files:

--- a/scripts/slack-refresh-tokens
+++ b/scripts/slack-refresh-tokens
@@ -78,7 +78,7 @@ if [[ -z "$SLACK_DIR" || ! -d "$SLACK_DIR" ]]; then
   exit 1
 fi
 
-echo "Using Slack data directory: $SLACK_DIR"
+echo "Using Slack data directory: $SLACK_DIR" >&2
 
 if [[ ! -f "$SLACK_DIR/Cookies" ]]; then
   echo "ERROR: No Cookies database — is the Slack app signed in?" >&2

--- a/scripts/slack-refresh-tokens
+++ b/scripts/slack-refresh-tokens
@@ -116,14 +116,19 @@ slack_dir = os.environ['SLACK_DIR']
 bus = secretstorage.dbus_init()
 keyring_pass = None
 for coll in secretstorage.get_all_collections(bus):
-    for item in coll.get_all_items():
-        attrs = item.get_attributes()
-        if attrs.get('application') == 'Slack':
-            keyring_pass = item.get_secret().decode()
-            break
-        if attrs.get('user') == 'Slack Safe Storage' and attrs.get('server') == 'Slack Keys':
-            keyring_pass = item.get_secret().decode()
-            break
+    if coll.is_locked():
+        continue
+    try:
+        for item in coll.get_all_items():
+            attrs = item.get_attributes()
+            if attrs.get('application') == 'Slack':
+                keyring_pass = item.get_secret().decode()
+                break
+            if attrs.get('user') == 'Slack Safe Storage' and attrs.get('server') == 'Slack Keys':
+                keyring_pass = item.get_secret().decode()
+                break
+    except Exception:
+        pass
     if keyring_pass:
         break
 

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -58,6 +58,8 @@ SLACK_TEAM_ID = os.environ.get("SLACK_TEAM_ID", "")
 # Cache file path (in same directory as script)
 SCRIPT_DIR = Path(__file__).parent
 USER_CACHE_FILE = SCRIPT_DIR / ".user_cache.json"
+REVERSE_USER_CACHE_FILE = SCRIPT_DIR / ".reverse_user_cache.json"
+REVERSE_CACHE_TTL_HOURS = 24
 
 # Cache for channel name to ID mapping
 _channel_cache: dict[str, str] = {}
@@ -227,6 +229,92 @@ def _save_user_cache() -> None:
     except Exception as e:
         log(f"Error saving user cache: {e}")
 
+
+
+
+def _load_reverse_user_cache() -> list[dict[str, str]]:
+    """Load the reverse user cache from disk. Returns empty list if stale or missing."""
+    try:
+        if REVERSE_USER_CACHE_FILE.exists():
+            with open(REVERSE_USER_CACHE_FILE, 'r') as f:
+                data = json.load(f)
+            fetched_at = datetime.fromisoformat(data.get("fetched_at", "2000-01-01T00:00:00+00:00"))
+            age_hours = (datetime.now(timezone.utc) - fetched_at).total_seconds() / 3600
+            if age_hours < REVERSE_CACHE_TTL_HOURS:
+                users = data.get("users", [])
+                log(f"Loaded reverse user cache ({len(users)} users, {age_hours:.1f}h old)")
+                return users
+            log(f"Reverse user cache expired ({age_hours:.1f}h old)")
+    except Exception as e:
+        log(f"Error loading reverse user cache: {e}")
+    return []
+
+
+def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
+    """Save the reverse user cache to disk with a timestamp.
+
+    Emails are excluded from the persisted payload to avoid storing PII on disk.
+    """
+    try:
+        sanitized = [{k: v for k, v in u.items() if k != "email"} for u in users]
+        data = {
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+            "users": sanitized,
+        }
+        with open(REVERSE_USER_CACHE_FILE, 'w') as f:
+            json.dump(data, f, indent=2)
+        log(f"Saved reverse user cache ({len(sanitized)} users)")
+    except Exception as e:
+        log(f"Error saving reverse user cache: {e}")
+
+
+async def _fetch_all_users() -> list[dict[str, str]]:
+    """Fetch all workspace users via users.list with pagination. Returns simplified user records."""
+    cached = _load_reverse_user_cache()
+    if cached:
+        return cached
+
+    url = f"{SLACK_API_BASE}/users.list"
+    all_users: list[dict[str, str]] = []
+    cursor = None
+
+    while True:
+        payload: dict[str, Any] = {"limit": 200}
+        if cursor:
+            payload["cursor"] = cursor
+
+        data = await make_request(url, method="GET", payload=payload)
+        if not data or not data.get("ok"):
+            error_msg = data.get("error", "Unknown error") if data else "No response"
+            log(f"Error fetching users.list: {error_msg}")
+            break
+
+        for member in data.get("members", []):
+            if member.get("deleted") or member.get("is_bot"):
+                continue
+            profile = member.get("profile", {})
+            all_users.append({
+                "id": member.get("id", ""),
+                "handle": member.get("name", ""),
+                "real_name": member.get("real_name", ""),
+                "display_name": profile.get("display_name", ""),
+                "email": profile.get("email", ""),
+            })
+
+        cursor = data.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            break
+
+    if all_users:
+        _save_reverse_user_cache(all_users)
+        global _user_cache
+        for u in all_users:
+            display = u["display_name"] or u["real_name"] or u["handle"] or u["id"]
+            _user_cache[u["id"]] = display
+        _save_user_cache()
+
+    log(f"Fetched {len(all_users)} users from workspace")
+    return all_users
 
 async def get_user_handle(user_id: str) -> str:
     """Get user handle by ID with caching. Returns user_id if lookup fails."""
@@ -574,6 +662,49 @@ async def refresh_user_cache() -> int:
         log(f"Cleared {count} user cache entries but failed to delete cache file: {e}")
 
     return count
+
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True))
+async def resolve_user_id(query: str) -> list[dict[str, str]]:
+    """Resolve a Slack user ID from a name, @handle, or email address.
+
+    Searches the full workspace member list (cached for 24h).
+    Returns up to 5 matches sorted by relevance: exact handle > exact email >
+    case-insensitive name > partial substring match.
+    Each result contains id, handle, real_name, display_name, and email.
+    """
+    await log_to_slack(f"Resolving user ID for: {query}")
+    users = await _fetch_all_users()
+    if not users:
+        return []
+
+    q = query.strip().lstrip("@").lower()
+    if not q:
+        return []
+
+    exact_handle: list[dict[str, str]] = []
+    exact_email: list[dict[str, str]] = []
+    exact_name: list[dict[str, str]] = []
+    partial: list[dict[str, str]] = []
+
+    for u in users:
+        handle = u.get("handle", "").lower()
+        email = u.get("email", "").lower()
+        real = u.get("real_name", "").lower()
+        display = u.get("display_name", "").lower()
+
+        if handle == q:
+            exact_handle.append(u)
+        elif email == q or email.split("@")[0] == q:
+            exact_email.append(u)
+        elif real == q or display == q:
+            exact_name.append(u)
+        elif q in handle or q in real or q in display or q in email:
+            partial.append(u)
+
+    results = exact_handle + exact_email + exact_name + partial
+    return results[:5]
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -606,7 +606,7 @@ async def post_message(
     if not unfurl_media:
         payload["unfurl_media"] = False
     data = await make_request(url, payload=payload)
-    return data.get("ok")
+    return bool(data and data.get("ok"))
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
@@ -623,7 +623,7 @@ async def post_command(
     url = f"{SLACK_API_BASE}/chat.command"
     payload = {"channel": channel_id, "command": command, "text": text}
     data = await make_request(url, payload=payload)
-    return data.get("ok")
+    return bool(data and data.get("ok"))
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
@@ -640,7 +640,7 @@ async def add_reaction(channel_id: str, message_ts: str, reaction: str) -> bool:
         "timestamp": convert_thread_ts(message_ts),
     }
     data = await make_request(url, payload=payload)
-    return data.get("ok")
+    return bool(data and data.get("ok"))
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
 async def get_reactions(
@@ -669,7 +669,7 @@ async def whoami() -> str:
     await log_to_slack("Checking authentication & identity")
     url = f"{SLACK_API_BASE}/auth.test"
     data = await make_request(url)
-    return data.get("user")
+    return data.get("user") if data else None
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
@@ -681,7 +681,7 @@ async def join_channel(channel_id: str, skip_log: bool = False) -> bool:
     url = f"{SLACK_API_BASE}/conversations.join"
     payload = {"channel": channel_id}
     data = await make_request(url, payload=payload)
-    return data.get("ok")
+    return bool(data and data.get("ok"))
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
@@ -965,7 +965,7 @@ async def send_dm(
     url = f"{SLACK_API_BASE}/conversations.open"
     payload = {"users": user_id, "return_dm": True}
     data = await make_request(url, payload=payload)
-    if data.get("ok"):
+    if data and data.get("ok"):
         return await post_message(
             data.get("channel").get("id"),
             message,

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -977,7 +977,13 @@ async def send_dm(
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
-async def send_group_dm(user_ids: list[str], message: str) -> bool:
+async def send_group_dm(
+    user_ids: list[str],
+    message: str,
+    unfurl_links: bool = True,
+    unfurl_media: bool = True,
+    blocks: str = "",
+) -> bool:
     """Send a message to a group DM (multi-party direct message).
 
     Args:
@@ -1014,7 +1020,14 @@ async def send_group_dm(user_ids: list[str], message: str) -> bool:
         log("Error: No channel ID returned from conversations.open")
         return False
 
-    return await post_message(channel_id, message, skip_log=True)
+    return await post_message(
+        channel_id,
+        message,
+        skip_log=True,
+        unfurl_links=unfurl_links,
+        unfurl_media=unfurl_media,
+        blocks=blocks,
+    )
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -594,7 +594,11 @@ async def post_message(
     url = f"{SLACK_API_BASE}/chat.postMessage"
     payload = {"channel": channel_id, "text": message}
     if blocks:
-        payload["blocks"] = json.loads(blocks)
+        try:
+            payload["blocks"] = json.loads(blocks)
+        except json.JSONDecodeError as e:
+            log(f"Error: invalid blocks JSON: {e}")
+            return False
     if thread_ts:
         payload["thread_ts"] = convert_thread_ts(thread_ts)
     if not unfurl_links:

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -68,6 +68,19 @@ _user_cache: dict[str, str] = {}
 mcp = FastMCP("slack")
 
 
+def _get_session_tokens_from_env() -> tuple[str, str] | None:
+    """Return (xoxc, xoxd) from environment if both are set, else None.
+
+    Accepts either SLACK_XOXC_TOKEN / SLACK_XOXD_TOKEN or their
+    SLACK_MCP_* variants (the token file written by slack-refresh-tokens).
+    """
+    xoxc = os.environ.get("SLACK_XOXC_TOKEN") or os.environ.get("SLACK_MCP_XOXC_TOKEN", "")
+    xoxd = os.environ.get("SLACK_XOXD_TOKEN") or os.environ.get("SLACK_MCP_XOXD_TOKEN", "")
+    if xoxc and xoxd:
+        return xoxc, xoxd
+    return None
+
+
 async def make_request(
     url: str, method: str = "POST", payload: dict[str, Any] | None = None
 ) -> dict[str, Any] | None:
@@ -79,18 +92,16 @@ async def make_request(
             "Content-Type": "application/json",
             "User-Agent": "MCP-Server/1.0",
         }
-    elif MCP_TRANSPORT == "stdio":
-        xoxc_token = os.environ["SLACK_XOXC_TOKEN"]
-        xoxd_token = os.environ["SLACK_XOXD_TOKEN"]
+    elif (env_tokens := _get_session_tokens_from_env()):
+        xoxc_token, xoxd_token = env_tokens
         headers = {
             "Authorization": f"Bearer {xoxc_token}",
             "Content-Type": "application/json",
             "User-Agent": "MCP-Server/1.0",
         }
         cookies = {"d": xoxd_token}
-    else:
+    elif MCP_TRANSPORT != "stdio":
         request_headers = mcp.get_context().request_context.request.headers
-        # Support either bot token or user session tokens
         if "X-Slack-Bot-Token" in request_headers:
             bot_token = request_headers["X-Slack-Bot-Token"]
             headers = {
@@ -106,6 +117,9 @@ async def make_request(
                 "User-Agent": request_headers.get("User-Agent", "MCP-Server/1.0"),
             }
             cookies = {"d": xoxd_token}
+    else:
+        log("Error: stdio mode requires SLACK_XOXC_TOKEN and SLACK_XOXD_TOKEN (or SLACK_BOT_TOKEN)")
+        return None
 
     async with httpx.AsyncClient(cookies=cookies) as client:
         try:
@@ -564,17 +578,29 @@ async def refresh_user_cache() -> int:
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_message(
-    channel_id: str, message: str, thread_ts: str = "", skip_log: bool = False
+    channel_id: str,
+    message: str,
+    thread_ts: str = "",
+    skip_log: bool = False,
+    unfurl_links: bool = True,
+    unfurl_media: bool = True,
+    blocks: str = "",
 ) -> bool:
-    """Post a message to a channel."""
+    """Post a message to a channel. Optionally pass Block Kit blocks as a JSON string for rich formatting (e.g. nested lists via rich_text blocks). When blocks is provided, message is used as the plaintext fallback."""
     _deny_if_read_only()
     if not skip_log:
         await log_to_slack(f"Posting message to channel <#{channel_id}>: {message}")
     await join_channel(channel_id, skip_log=skip_log)
     url = f"{SLACK_API_BASE}/chat.postMessage"
     payload = {"channel": channel_id, "text": message}
+    if blocks:
+        payload["blocks"] = json.loads(blocks)
     if thread_ts:
         payload["thread_ts"] = convert_thread_ts(thread_ts)
+    if not unfurl_links:
+        payload["unfurl_links"] = False
+    if not unfurl_media:
+        payload["unfurl_media"] = False
     data = await make_request(url, payload=payload)
     return data.get("ok")
 
@@ -922,15 +948,27 @@ async def clear_usergroup(usergroup_id: str) -> bool:
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
-async def send_dm(user_id: str, message: str) -> bool:
-    """Send a direct message to a user."""
+async def send_dm(
+    user_id: str,
+    message: str,
+    unfurl_links: bool = True,
+    unfurl_media: bool = True,
+    blocks: str = "",
+) -> bool:
+    """Send a direct message to a user. Optionally pass Block Kit blocks as a JSON string for rich formatting (e.g. nested lists via rich_text blocks). When blocks is provided, message is used as the plaintext fallback."""
     _deny_if_read_only()
     await log_to_slack(f"Sending direct message to user <@{user_id}>: {message}")
     url = f"{SLACK_API_BASE}/conversations.open"
     payload = {"users": user_id, "return_dm": True}
     data = await make_request(url, payload=payload)
     if data.get("ok"):
-        return await post_message(data.get("channel").get("id"), message)
+        return await post_message(
+            data.get("channel").get("id"),
+            message,
+            unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
+            blocks=blocks,
+        )
     return False
 
 
@@ -1103,11 +1141,13 @@ if __name__ == "__main__":
         if not SLACK_BOT_TOKEN.startswith("xoxb-"):
             log("Warning: SLACK_BOT_TOKEN does not start with xoxb- — is this a valid bot token?")
         log("slack-mcp: using bot token authentication (scoped)")
-    elif MCP_TRANSPORT == "stdio":
-        if not os.environ.get("SLACK_XOXC_TOKEN") or not os.environ.get("SLACK_XOXD_TOKEN"):
-            log("Error: stdio mode requires SLACK_XOXC_TOKEN and SLACK_XOXD_TOKEN (or SLACK_BOT_TOKEN)")
-            sys.exit(1)
+    elif _get_session_tokens_from_env():
         log("slack-mcp: using browser session token authentication (full user access)")
+    elif MCP_TRANSPORT == "stdio":
+        log("Error: stdio mode requires SLACK_XOXC_TOKEN and SLACK_XOXD_TOKEN (or SLACK_BOT_TOKEN)")
+        sys.exit(1)
+    else:
+        log("slack-mcp: no server-side tokens — expecting per-request auth headers")
     if _is_read_only():
         log(
             f"slack-mcp: read-only mode is active ({READ_ONLY_ENV_VAR}); "

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -975,7 +975,7 @@ async def list_joined_channels(
 
         if not data or not data.get("ok"):
             error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
-            print(f"Error listing joined channels: {error_msg}")
+            log(f"Error listing joined channels: {error_msg}")
             break
 
         for ch in data.get("channels", []):
@@ -995,7 +995,7 @@ async def list_joined_channels(
         if not cursor:
             break
 
-    print(f"Listed {len(all_channels)} joined channels")
+    log(f"Listed {len(all_channels)} joined channels")
     return all_channels
 
 
@@ -1256,7 +1256,7 @@ async def search_channel_messages(
 
         if not data or not data.get("ok"):
             error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
-            print(f"Error searching channel messages: {error_msg}")
+            log(f"Error searching channel messages: {error_msg}")
             break
 
         messages_data = data.get("messages", {})
@@ -1269,7 +1269,7 @@ async def search_channel_messages(
 
         page += 1
 
-    print(f"Retrieved {len(all_matches)} search results for query in channel {channel_id}")
+    log(f"Retrieved {len(all_matches)} search results for query in channel {channel_id}")
 
     unique_users = {msg.get("user") for msg in all_matches if msg.get("user")}
     mention_pattern = r'<@([A-Z0-9]+)>'

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -1098,8 +1098,9 @@ async def send_dm(
     data = await make_request(url, payload=payload)
     if data and data.get("ok"):
         return await post_message(
-            data.get("channel").get("id"),
+            data.get("channel", {}).get("id"),
             message,
+            skip_log=True,
             unfurl_links=unfurl_links,
             unfurl_media=unfurl_media,
             blocks=blocks,


### PR DESCRIPTION
## Summary

- Add optional `blocks` param (JSON string) to `post_message`, `send_dm`, and `send_group_dm` for rich formatting via Slack's Block Kit (e.g. nested bullet lists using `rich_text` blocks). `message` becomes the plaintext fallback when blocks is provided.
- Add `unfurl_links` / `unfurl_media` controls to `post_message`, `send_dm`, and `send_group_dm`.
- Refactor session token resolution into `_get_session_tokens_from_env()` for cleaner auth precedence (bot token > env session > request headers).
- Add Flatpak auto-detection and `secretstorage` keyring access to `slack-refresh-tokens` (replaces `secret-tool` CLI dependency).

## Bug fixes

- Handle malformed `blocks` JSON gracefully (catch `JSONDecodeError`, return `False` instead of crashing)
- Guard all `data.get("ok")` calls against `None` returns from `make_request` (prevents `AttributeError` on network/auth failures)
- Fix shell injection in `slack-refresh-tokens` when `--slack-dir` path contains single quotes (pass via `os.environ` instead of bash interpolation)

## Test plan

- [x] Verified Block Kit nested bullets render correctly in Slack DMs via MCP `send_dm`
- [x] Verified plain text fallback still works when `blocks` is omitted
- [x] Verified `unfurl_links=false` / `unfurl_media=false` suppress link previews
- [ ] Verify `send_group_dm` with blocks param
- [ ] Verify `slack-refresh-tokens` on both native and Flatpak Slack installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)