### PR TITLE
feat: add formatting guide tool and auto-resolve @mentions/#channels

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,11 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade setuptools pip && \
     pip install --no-cache-dir -r requirements.txt
 
-COPY slack_mcp_server.py ./
+COPY slack_mcp_server.py formatting_guide.json ./
+COPY scripts/update_formatting_guide.py ./scripts/
+
+# Validate the formatting guide against Slack's live docs (best-effort).
+# In hermetic builds without network, this logs a warning and continues.
+RUN python scripts/update_formatting_guide.py --check || true
 
 CMD ["python", "slack_mcp_server.py"]

--- a/formatting_guide.json
+++ b/formatting_guide.json
@@ -1,0 +1,177 @@
+{
+  "source": "https://docs.slack.dev/messaging/formatting-message-text",
+  "description": "Slack mrkdwn formatting reference. Slack uses mrkdwn, NOT standard Markdown. Key differences: *bold* (not **bold**), _italic_ (not *italic*), <url|text> (not [text](url)).",
+  "rules": [
+    {
+      "name": "bold",
+      "syntax": "*text*",
+      "description": "Bold text. Note: standard Markdown uses **text** for bold, but Slack uses single asterisks.",
+      "example": "*important*"
+    },
+    {
+      "name": "italic",
+      "syntax": "_text_",
+      "description": "Italic text. Note: in standard Markdown *text* means italic, but in Slack *text* means bold. Use underscores for italic.",
+      "example": "_emphasis_"
+    },
+    {
+      "name": "strikethrough",
+      "syntax": "~text~",
+      "description": "Strikethrough text. Standard Markdown uses ~~text~~ (double tilde), Slack uses single tilde.",
+      "example": "~removed~"
+    },
+    {
+      "name": "inline-code",
+      "syntax": "`text`",
+      "description": "Inline code. Same as standard Markdown. Text inside will not use any other formatting.",
+      "example": "use the `print()` function"
+    },
+    {
+      "name": "code-block",
+      "syntax": "```text```",
+      "description": "Multi-line code block. Do NOT include a language hint after the opening backticks — Slack does not support syntax highlighting and will render the language name as code.",
+      "example": "```\nimport os\nprint(os.getcwd())\n```"
+    },
+    {
+      "name": "blockquote",
+      "syntax": ">text",
+      "description": "Block quote. Prefix each quoted line with >. Each consecutive quoted line needs its own > prefix.",
+      "example": ">This is quoted\n>This is also quoted"
+    },
+    {
+      "name": "link",
+      "syntax": "<url|display text>",
+      "description": "Named link. Standard Markdown uses [text](url) but Slack uses angle brackets with a pipe separator. Plain URLs are auto-linked.",
+      "example": "<https://example.com|Click here>"
+    },
+    {
+      "name": "email-link",
+      "syntax": "<mailto:user@example.com|display text>",
+      "description": "Email link. Must use mailto: prefix.",
+      "example": "<mailto:team@example.com|Email the team>"
+    },
+    {
+      "name": "line-break",
+      "syntax": "\\n",
+      "description": "Newline. Use the literal string \\n in API-submitted text.",
+      "example": "Line one\\nLine two"
+    },
+    {
+      "name": "unordered-list",
+      "syntax": "• item",
+      "description": "Simulated bullet list. Slack has no native list syntax. Use the bullet character (•) with newlines.",
+      "example": "• Item one\\n• Item two\\n• Item three"
+    },
+    {
+      "name": "emoji",
+      "syntax": ":emoji_name:",
+      "description": "Emoji in colon format. Unicode emoji are also supported and auto-converted to colon format.",
+      "example": ":tada: :rocket: :white_check_mark:"
+    },
+    {
+      "name": "date",
+      "syntax": "<!date^UNIX_TIMESTAMP^{token_string}^optional_link|fallback>",
+      "description": "Dynamic date formatting. Renders dates in the viewer's local timezone. Tokens: {date_num}, {date}, {date_short}, {date_long}, {date_pretty}, {time}, {time_secs}, {ago}.",
+      "example": "<!date^1704067200^{date_short} at {time}|Jan 1, 2024>"
+    }
+  ],
+  "mentions": [
+    {
+      "name": "user-mention",
+      "syntax": "<@USER_ID>",
+      "description": "Mention a user by their Slack user ID (e.g. U012AB3CD). Do NOT use @username — it renders as plain text. Use resolve_user_id to look up the ID from a name.",
+      "example": "<@U012AB3CD>"
+    },
+    {
+      "name": "channel-link",
+      "syntax": "<#CHANNEL_ID>",
+      "description": "Link to a channel by its ID (e.g. C012AB3CD). Do NOT use #channel-name — it may not link. Use get_channel_id_by_name to look up the ID.",
+      "example": "<#C012AB3CD>"
+    },
+    {
+      "name": "user-group-mention",
+      "syntax": "<!subteam^GROUP_ID>",
+      "description": "Mention a user group by ID. The literal string !subteam^ is required before the group ID.",
+      "example": "<!subteam^SAZ94GDB8>"
+    },
+    {
+      "name": "here",
+      "syntax": "<!here>",
+      "description": "Notify active members of the channel. Use sparingly."
+    },
+    {
+      "name": "channel-notify",
+      "syntax": "<!channel>",
+      "description": "Notify ALL members of the channel, active or not."
+    },
+    {
+      "name": "everyone",
+      "syntax": "<!everyone>",
+      "description": "Notify everyone in #general. Most disruptive — use with extreme care."
+    }
+  ],
+  "escaping": [
+    {
+      "character": "&",
+      "escape_as": "&amp;",
+      "description": "Ampersand must be escaped as HTML entity"
+    },
+    {
+      "character": "<",
+      "escape_as": "&lt;",
+      "description": "Less-than must be escaped as HTML entity"
+    },
+    {
+      "character": ">",
+      "escape_as": "&gt;",
+      "description": "Greater-than must be escaped when used as literal text (not for blockquotes or link syntax)"
+    }
+  ],
+  "unsupported": [
+    {
+      "feature": "headings",
+      "markdown_syntax": "# Heading",
+      "note": "Not supported in mrkdwn. Use *bold text* on its own line, or header blocks in Block Kit."
+    },
+    {
+      "feature": "images",
+      "markdown_syntax": "![alt](url)",
+      "note": "Not supported in mrkdwn. Use image blocks in Block Kit."
+    },
+    {
+      "feature": "tables",
+      "markdown_syntax": "| col | col |",
+      "note": "Not supported in mrkdwn. Use code blocks for tabular data or rich_text blocks."
+    },
+    {
+      "feature": "ordered-lists",
+      "markdown_syntax": "1. item",
+      "note": "No native support. Simulate with numbered text and newlines: 1. item\\n2. item"
+    },
+    {
+      "feature": "horizontal-rule",
+      "markdown_syntax": "---",
+      "note": "Not supported in mrkdwn. Use divider blocks in Block Kit."
+    },
+    {
+      "feature": "nested-formatting",
+      "markdown_syntax": "**_bold italic_**",
+      "note": "Nested inline formatting is not reliably supported."
+    },
+    {
+      "feature": "markdown-bold",
+      "markdown_syntax": "**text**",
+      "note": "Does NOT work. Use *text* instead (single asterisks)."
+    },
+    {
+      "feature": "markdown-links",
+      "markdown_syntax": "[text](url)",
+      "note": "Does NOT work. Use <url|text> instead."
+    },
+    {
+      "feature": "code-block-language",
+      "markdown_syntax": "```python",
+      "note": "Language hints are NOT supported. The language name will be rendered as part of the code. Use plain ``` with no language."
+    }
+  ]
+}

--- a/scripts/update_formatting_guide.py
+++ b/scripts/update_formatting_guide.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Scrape Slack's mrkdwn formatting docs and update formatting_guide.json.
+
+Run at container build time or manually to keep the guide current.
+Falls back to the existing file if the fetch fails (e.g. hermetic builds).
+
+Usage:
+    python3 scripts/update_formatting_guide.py [--check]
+
+    --check   Compare scraped content against the existing guide and exit
+              with code 1 if the docs appear to have changed (CI gate mode).
+"""
+import json
+import re
+import sys
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+
+DOCS_URL = "https://docs.slack.dev/messaging/formatting-message-text"
+GUIDE_FILE = Path(__file__).resolve().parent.parent / "formatting_guide.json"
+
+
+class SlackDocsParser(HTMLParser):
+    """Extract text content from the Slack formatting docs page."""
+
+    def __init__(self):
+        super().__init__()
+        self.text_parts: list[str] = []
+        self._skip = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style", "nav", "footer"):
+            self._skip = True
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style", "nav", "footer"):
+            self._skip = False
+
+    def handle_data(self, data):
+        if not self._skip:
+            stripped = data.strip()
+            if stripped:
+                self.text_parts.append(stripped)
+
+
+def fetch_docs_text() -> str | None:
+    """Fetch the Slack formatting docs and return extracted text."""
+    try:
+        req = urllib.request.Request(DOCS_URL, headers={"User-Agent": "slack-mcp-guide-updater/1.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8")
+        parser = SlackDocsParser()
+        parser.feed(html)
+        return "\n".join(parser.text_parts)
+    except Exception as e:
+        print(f"Warning: could not fetch Slack docs: {e}", file=sys.stderr)
+        return None
+
+
+# Known formatting markers we expect to find in the docs.
+# If any are missing, the page structure may have changed.
+EXPECTED_MARKERS = [
+    "*bold*",
+    "_italic_",
+    "~strike~",
+    "<@",
+    "<#",
+    "<!here>",
+    "@channel",
+    "```",
+    "&amp;",
+    "&lt;",
+    "&gt;",
+    "<!date^",
+]
+
+
+def check_markers(text: str) -> list[str]:
+    """Return any expected markers NOT found in the scraped text."""
+    return [m for m in EXPECTED_MARKERS if m not in text]
+
+
+def main():
+    check_mode = "--check" in sys.argv
+
+    docs_text = fetch_docs_text()
+    if docs_text is None:
+        if check_mode:
+            print("SKIP: could not fetch docs (network unavailable)")
+            sys.exit(0)
+        print("Falling back to existing formatting_guide.json", file=sys.stderr)
+        sys.exit(0)
+
+    missing = check_markers(docs_text)
+    if missing:
+        print(f"Warning: {len(missing)} expected markers not found in docs: {missing}", file=sys.stderr)
+        print("The Slack formatting docs may have changed structure.", file=sys.stderr)
+        if check_mode:
+            print("STALE: formatting guide may need updating")
+            sys.exit(1)
+    else:
+        print(f"All {len(EXPECTED_MARKERS)} expected markers found in docs")
+        if check_mode:
+            print("OK: formatting guide appears current")
+            sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -707,6 +707,91 @@ async def resolve_user_id(query: str) -> list[dict[str, str]]:
     return results[:5]
 
 
+FORMATTING_GUIDE_FILE = SCRIPT_DIR / "formatting_guide.json"
+_formatting_guide: dict[str, Any] | None = None
+
+
+def _load_formatting_guide() -> dict[str, Any]:
+    """Load the Slack mrkdwn formatting guide from formatting_guide.json."""
+    global _formatting_guide
+    if _formatting_guide is not None:
+        return _formatting_guide
+
+    try:
+        if FORMATTING_GUIDE_FILE.exists():
+            with open(FORMATTING_GUIDE_FILE, "r") as f:
+                _formatting_guide = json.load(f)
+            log(f"Loaded formatting guide from {FORMATTING_GUIDE_FILE.name}")
+            return _formatting_guide
+    except Exception as e:
+        log(f"Error loading formatting guide: {e}")
+
+    _formatting_guide = {"rules": [], "unsupported": []}
+    return _formatting_guide
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
+async def get_formatting_guide() -> dict[str, Any]:
+    """Get the Slack mrkdwn formatting guide for composing messages.
+
+    Call this before composing a Slack message. Slack uses mrkdwn, NOT standard
+    Markdown — the syntax differs in important ways.
+
+    Returns a guide with:
+    - rules: supported formatting options with syntax and examples
+    - unsupported: standard Markdown features that do NOT work in Slack
+    - escaping: characters that must be HTML-entity-escaped
+    - mentions: how to reference users, channels, and groups
+    """
+    return _load_formatting_guide()
+
+
+async def _resolve_mentions(text: str) -> str:
+    """Resolve @name references to Slack <@USER_ID> format.
+
+    Skips references already in <@...> format. Failed lookups are left unchanged.
+    Results are cached via _fetch_all_users() (24h TTL).
+    """
+    mention_pattern = r"(?<![<])@([\w][\w.\-]*)"
+    matches = list(re.finditer(mention_pattern, text))
+    if not matches:
+        return text
+
+    queries = {m.group(1) for m in matches}
+    resolved: dict[str, str] = {}
+    for query in queries:
+        users = await resolve_user_id(query)
+        if users:
+            resolved[query] = f"<@{users[0]['id']}>"
+
+    for query, replacement in resolved.items():
+        text = text.replace(f"@{query}", replacement)
+    return text
+
+
+async def _resolve_channels(text: str) -> str:
+    """Resolve #channel references to Slack <#CHANNEL_ID> format.
+
+    Skips references already in <#...> format. Failed lookups are left unchanged.
+    Results are cached via _channel_cache.
+    """
+    channel_pattern = r"(?<![<])#([\w][\w-]*)"
+    matches = list(re.finditer(channel_pattern, text))
+    if not matches:
+        return text
+
+    queries = {m.group(1) for m in matches}
+    resolved: dict[str, str] = {}
+    for name in queries:
+        channel_id = await get_channel_id_by_name(name)
+        if channel_id:
+            resolved[name] = f"<#{channel_id}>"
+
+    for name, replacement in resolved.items():
+        text = text.replace(f"#{name}", replacement)
+    return text
+
+
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def post_message(
     channel_id: str,
@@ -716,9 +801,26 @@ async def post_message(
     unfurl_links: bool = True,
     unfurl_media: bool = True,
     blocks: str = "",
+    resolve_references: bool = True,
 ) -> bool:
-    """Post a message to a channel. Optionally pass Block Kit blocks as a JSON string for rich formatting (e.g. nested lists via rich_text blocks). When blocks is provided, message is used as the plaintext fallback."""
+    """Post a message to a channel.
+
+    IMPORTANT: Slack uses mrkdwn, NOT standard Markdown. You MUST call
+    get_formatting_guide first to learn the correct syntax before composing
+    the message.
+
+    By default, @handle and #channel references in the message text are automatically
+    resolved to Slack user/channel IDs so they render as proper mentions and links.
+    Set resolve_references=False to skip this if the message already uses
+    <@USER_ID>/<#CHANNEL_ID> format.
+
+    Optionally pass Block Kit blocks as a JSON string for rich formatting (e.g. nested
+    lists via rich_text blocks). When blocks is provided, message is used as the
+    plaintext fallback."""
     _deny_if_read_only()
+    if resolve_references:
+        message = await _resolve_mentions(message)
+        message = await _resolve_channels(message)
     if not skip_log:
         await log_to_slack(f"Posting message to channel <#{channel_id}>: {message}")
     await join_channel(channel_id, skip_log=skip_log)
@@ -1089,8 +1191,17 @@ async def send_dm(
     unfurl_links: bool = True,
     unfurl_media: bool = True,
     blocks: str = "",
+    resolve_references: bool = True,
 ) -> bool:
-    """Send a direct message to a user. Optionally pass Block Kit blocks as a JSON string for rich formatting (e.g. nested lists via rich_text blocks). When blocks is provided, message is used as the plaintext fallback."""
+    """Send a direct message to a user.
+
+    IMPORTANT: Slack uses mrkdwn, NOT standard Markdown. You MUST call
+    get_formatting_guide first to learn the correct syntax before composing
+    the message.
+
+    By default, @handle and #channel references are auto-resolved to Slack IDs.
+    Optionally pass Block Kit blocks as a JSON string for rich formatting. When blocks
+    is provided, message is used as the plaintext fallback."""
     _deny_if_read_only()
     await log_to_slack(f"Sending direct message to user <@{user_id}>: {message}")
     url = f"{SLACK_API_BASE}/conversations.open"
@@ -1104,6 +1215,7 @@ async def send_dm(
             unfurl_links=unfurl_links,
             unfurl_media=unfurl_media,
             blocks=blocks,
+            resolve_references=resolve_references,
         )
     return False
 
@@ -1115,8 +1227,15 @@ async def send_group_dm(
     unfurl_links: bool = True,
     unfurl_media: bool = True,
     blocks: str = "",
+    resolve_references: bool = True,
 ) -> bool:
     """Send a message to a group DM (multi-party direct message).
+
+    IMPORTANT: Slack uses mrkdwn, NOT standard Markdown. You MUST call
+    get_formatting_guide first to learn the correct syntax before composing
+    the message.
+
+    By default, @handle and #channel references are auto-resolved to Slack IDs.
 
     Args:
         user_ids: List of 2+ user IDs to include in group DM
@@ -1159,6 +1278,7 @@ async def send_group_dm(
         unfurl_links=unfurl_links,
         unfurl_media=unfurl_media,
         blocks=blocks,
+        resolve_references=resolve_references,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Add repo root to path so we can import slack_mcp_server
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches(monkeypatch, tmp_path):
+    """Redirect cache files to a temp directory and reset in-memory caches."""
+    import slack_mcp_server as sms
+
+    monkeypatch.setattr(sms, "USER_CACHE_FILE", tmp_path / ".user_cache.json")
+    monkeypatch.setattr(sms, "REVERSE_USER_CACHE_FILE", tmp_path / ".reverse_user_cache.json")
+    monkeypatch.setattr(sms, "FORMATTING_GUIDE_FILE", tmp_path / "formatting_guide.json")
+
+    sms._user_cache.clear()
+    sms._channel_cache.clear()
+    sms._formatting_guide = None
+
+
+@pytest.fixture
+def mock_make_request():
+    """Patch make_request to avoid real Slack API calls."""
+    with patch("slack_mcp_server.make_request", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_log_to_slack():
+    """Patch log_to_slack to suppress logging side effects."""
+    with patch("slack_mcp_server.log_to_slack", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+@pytest.fixture
+def sample_formatting_guide(tmp_path):
+    """Write a minimal formatting_guide.json and point the module at it."""
+    import json
+    import slack_mcp_server as sms
+
+    guide = {
+        "source": "https://docs.slack.dev/messaging/formatting-message-text",
+        "description": "Test guide",
+        "rules": [
+            {
+                "name": "bold",
+                "syntax": "*text*",
+                "description": "Bold text",
+                "example": "*important*",
+            }
+        ],
+        "mentions": [
+            {
+                "name": "user-mention",
+                "syntax": "<@USER_ID>",
+                "description": "Mention a user by ID",
+                "example": "<@U012AB3CD>",
+            }
+        ],
+        "escaping": [
+            {
+                "character": "&",
+                "escape_as": "&amp;",
+                "description": "Ampersand",
+            }
+        ],
+        "unsupported": [
+            {
+                "feature": "markdown-bold",
+                "markdown_syntax": "**text**",
+                "note": "Use *text* instead",
+            }
+        ],
+    }
+
+    guide_path = tmp_path / "formatting_guide.json"
+    guide_path.write_text(json.dumps(guide))
+    sms.FORMATTING_GUIDE_FILE = guide_path
+    sms._formatting_guide = None
+    return guide

--- a/tests/test_formatting_guide.py
+++ b/tests/test_formatting_guide.py
@@ -1,0 +1,90 @@
+"""Tests for get_formatting_guide and _load_formatting_guide."""
+
+import json
+
+import pytest
+
+import slack_mcp_server as sms
+
+
+class TestLoadFormattingGuide:
+    def test_loads_from_file(self, sample_formatting_guide):
+        guide = sms._load_formatting_guide()
+        assert guide["rules"][0]["name"] == "bold"
+        assert len(guide["unsupported"]) == 1
+
+    def test_caches_after_first_load(self, sample_formatting_guide):
+        first = sms._load_formatting_guide()
+        second = sms._load_formatting_guide()
+        assert first is second
+
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        sms.FORMATTING_GUIDE_FILE = tmp_path / "nonexistent.json"
+        guide = sms._load_formatting_guide()
+        assert guide == {"rules": [], "unsupported": []}
+
+    def test_returns_empty_on_invalid_json(self, tmp_path):
+        bad_file = tmp_path / "formatting_guide.json"
+        bad_file.write_text("not json{{{")
+        sms.FORMATTING_GUIDE_FILE = bad_file
+        guide = sms._load_formatting_guide()
+        assert guide == {"rules": [], "unsupported": []}
+
+
+class TestGetFormattingGuide:
+    @pytest.mark.asyncio
+    async def test_returns_guide(self, sample_formatting_guide):
+        guide = await sms.get_formatting_guide()
+        assert "rules" in guide
+        assert "mentions" in guide
+        assert "escaping" in guide
+        assert "unsupported" in guide
+
+    @pytest.mark.asyncio
+    async def test_guide_has_required_sections(self, sample_formatting_guide):
+        guide = await sms.get_formatting_guide()
+        assert isinstance(guide["rules"], list)
+        assert len(guide["rules"]) > 0
+        rule = guide["rules"][0]
+        assert "name" in rule
+        assert "syntax" in rule
+        assert "description" in rule
+
+    @pytest.mark.asyncio
+    async def test_guide_source_url(self, sample_formatting_guide):
+        guide = await sms.get_formatting_guide()
+        assert guide["source"].startswith("https://")
+
+
+class TestShippedFormattingGuide:
+    """Validate the actual formatting_guide.json shipped with the repo."""
+
+    @pytest.fixture(autouse=True)
+    def _use_real_guide(self):
+        from pathlib import Path
+
+        real_guide = Path(__file__).resolve().parent.parent / "formatting_guide.json"
+        sms.FORMATTING_GUIDE_FILE = real_guide
+        sms._formatting_guide = None
+
+    def test_shipped_guide_loads(self):
+        guide = sms._load_formatting_guide()
+        assert len(guide["rules"]) >= 10
+        assert len(guide["mentions"]) >= 4
+        assert len(guide["escaping"]) >= 3
+        assert len(guide["unsupported"]) >= 5
+
+    def test_shipped_guide_has_critical_rules(self):
+        guide = sms._load_formatting_guide()
+        rule_names = {r["name"] for r in guide["rules"]}
+        assert "bold" in rule_names
+        assert "italic" in rule_names
+        assert "code-block" in rule_names
+        assert "link" in rule_names
+
+    def test_shipped_guide_warns_about_markdown_bold(self):
+        guide = sms._load_formatting_guide()
+        unsupported_features = {u["feature"] for u in guide["unsupported"]}
+        assert "markdown-bold" in unsupported_features
+        assert "markdown-links" in unsupported_features
+        assert "code-block-language" in unsupported_features

--- a/tests/test_resolve_references.py
+++ b/tests/test_resolve_references.py
@@ -1,0 +1,209 @@
+"""Tests for _resolve_mentions, _resolve_channels, and auto-resolution in post/send."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import slack_mcp_server as sms
+
+
+class TestResolveMentions:
+    @pytest.mark.asyncio
+    async def test_resolves_simple_handle(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = [{"id": "U12345", "handle": "jdoe"}]
+            result = await sms._resolve_mentions("Hey @jdoe check this")
+            assert result == "Hey <@U12345> check this"
+            mock_resolve.assert_called_once_with("jdoe")
+
+    @pytest.mark.asyncio
+    async def test_resolves_dotted_handle(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = [{"id": "U99999", "handle": "john.doe"}]
+            result = await sms._resolve_mentions("cc @john.doe")
+            assert result == "cc <@U99999>"
+
+    @pytest.mark.asyncio
+    async def test_resolves_hyphenated_handle(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = [{"id": "UABC", "handle": "jane-smith"}]
+            result = await sms._resolve_mentions("ping @jane-smith")
+            assert result == "ping <@UABC>"
+
+    @pytest.mark.asyncio
+    async def test_skips_already_formatted_mention(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            result = await sms._resolve_mentions("Hey <@U12345> check this")
+            assert result == "Hey <@U12345> check this"
+            mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leaves_unresolved_mention_unchanged(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = []
+            result = await sms._resolve_mentions("Hey @nonexistent")
+            assert result == "Hey @nonexistent"
+
+    @pytest.mark.asyncio
+    async def test_no_mentions_returns_unchanged(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            result = await sms._resolve_mentions("No mentions here")
+            assert result == "No mentions here"
+            mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_lookups(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = [{"id": "U11111", "handle": "alice"}]
+            result = await sms._resolve_mentions("@alice said hi to @alice")
+            assert result == "<@U11111> said hi to <@U11111>"
+            mock_resolve.assert_called_once_with("alice")
+
+    @pytest.mark.asyncio
+    async def test_multiple_different_mentions(self):
+        with patch.object(sms, "resolve_user_id", new_callable=AsyncMock) as mock_resolve:
+            async def side_effect(query):
+                users = {"alice": [{"id": "UA"}], "bob": [{"id": "UB"}]}
+                return users.get(query, [])
+
+            mock_resolve.side_effect = side_effect
+            result = await sms._resolve_mentions("@alice and @bob")
+            assert "<@UA>" in result
+            assert "<@UB>" in result
+            assert "@alice" not in result
+            assert "@bob" not in result
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self):
+        result = await sms._resolve_mentions("")
+        assert result == ""
+
+
+class TestResolveChannels:
+    @pytest.mark.asyncio
+    async def test_resolves_channel_name(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            mock_ch.return_value = "C12345"
+            result = await sms._resolve_channels("post in #general")
+            assert result == "post in <#C12345>"
+            mock_ch.assert_called_once_with("general")
+
+    @pytest.mark.asyncio
+    async def test_resolves_hyphenated_channel(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            mock_ch.return_value = "CABC"
+            result = await sms._resolve_channels("see #my-channel")
+            assert result == "see <#CABC>"
+
+    @pytest.mark.asyncio
+    async def test_skips_already_formatted_channel(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            result = await sms._resolve_channels("see <#C12345>")
+            assert result == "see <#C12345>"
+            mock_ch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leaves_unresolved_channel_unchanged(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            mock_ch.return_value = ""
+            result = await sms._resolve_channels("see #nonexistent")
+            assert result == "see #nonexistent"
+
+    @pytest.mark.asyncio
+    async def test_no_channels_returns_unchanged(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            result = await sms._resolve_channels("No channels here")
+            assert result == "No channels here"
+            mock_ch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_lookups(self):
+        with patch.object(sms, "get_channel_id_by_name", new_callable=AsyncMock) as mock_ch:
+            mock_ch.return_value = "C999"
+            result = await sms._resolve_channels("#dev and also #dev")
+            assert result == "<#C999> and also <#C999>"
+            mock_ch.assert_called_once_with("dev")
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self):
+        result = await sms._resolve_channels("")
+        assert result == ""
+
+
+class TestPostMessageResolveReferences:
+    @pytest.mark.asyncio
+    async def test_resolves_by_default(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True}
+
+        with (
+            patch.object(sms, "_resolve_mentions", new_callable=AsyncMock, return_value="resolved mentions") as mock_m,
+            patch.object(sms, "_resolve_channels", new_callable=AsyncMock, return_value="resolved all") as mock_c,
+            patch.object(sms, "join_channel", new_callable=AsyncMock),
+        ):
+            await sms.post_message("C123", "@alice in #general", skip_log=True)
+            mock_m.assert_called_once_with("@alice in #general")
+            mock_c.assert_called_once_with("resolved mentions")
+
+    @pytest.mark.asyncio
+    async def test_skips_resolution_when_disabled(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True}
+
+        with (
+            patch.object(sms, "_resolve_mentions", new_callable=AsyncMock) as mock_m,
+            patch.object(sms, "_resolve_channels", new_callable=AsyncMock) as mock_c,
+            patch.object(sms, "join_channel", new_callable=AsyncMock),
+        ):
+            await sms.post_message("C123", "<@U123> in <#C456>", skip_log=True, resolve_references=False)
+            mock_m.assert_not_called()
+            mock_c.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolved_text_is_sent(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True}
+
+        with (
+            patch.object(sms, "_resolve_mentions", new_callable=AsyncMock, return_value="<@U123> says hi"),
+            patch.object(sms, "_resolve_channels", new_callable=AsyncMock, return_value="<@U123> says hi in <#C456>"),
+            patch.object(sms, "join_channel", new_callable=AsyncMock),
+        ):
+            await sms.post_message("C789", "@alice says hi in #general", skip_log=True)
+            call_payload = mock_make_request.call_args
+            assert call_payload[1]["payload"]["text"] == "<@U123> says hi in <#C456>"
+
+
+class TestSendDmResolveReferences:
+    @pytest.mark.asyncio
+    async def test_passes_resolve_references_through(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True, "channel": {"id": "D999"}}
+
+        with patch.object(sms, "post_message", new_callable=AsyncMock, return_value=True) as mock_pm:
+            await sms.send_dm("U123", "hey @alice", resolve_references=False)
+            mock_pm.assert_called_once()
+            assert mock_pm.call_args[1]["resolve_references"] is False
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_resolve_true(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True, "channel": {"id": "D999"}}
+
+        with patch.object(sms, "post_message", new_callable=AsyncMock, return_value=True) as mock_pm:
+            await sms.send_dm("U123", "hey @alice")
+            assert mock_pm.call_args[1]["resolve_references"] is True
+
+
+class TestSendGroupDmResolveReferences:
+    @pytest.mark.asyncio
+    async def test_passes_resolve_references_through(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True, "channel": {"id": "G999"}}
+
+        with patch.object(sms, "post_message", new_callable=AsyncMock, return_value=True) as mock_pm:
+            await sms.send_group_dm(["U1", "U2"], "hey @bob", resolve_references=False)
+            mock_pm.assert_called_once()
+            assert mock_pm.call_args[1]["resolve_references"] is False
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_resolve_true(self, mock_make_request, mock_log_to_slack):
+        mock_make_request.return_value = {"ok": True, "channel": {"id": "G999"}}
+
+        with patch.object(sms, "post_message", new_callable=AsyncMock, return_value=True) as mock_pm:
+            await sms.send_group_dm(["U1", "U2"], "hey @bob")
+            assert mock_pm.call_args[1]["resolve_references"] is True

--- a/tests/test_update_formatting_guide.py
+++ b/tests/test_update_formatting_guide.py
@@ -1,0 +1,79 @@
+"""Tests for the update_formatting_guide.py scraper/checker script."""
+
+from unittest.mock import patch
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from update_formatting_guide import check_markers, EXPECTED_MARKERS, SlackDocsParser
+
+
+class TestCheckMarkers:
+    def test_all_markers_present(self):
+        text = " ".join(EXPECTED_MARKERS) + " extra content"
+        missing = check_markers(text)
+        assert missing == []
+
+    def test_some_markers_missing(self):
+        text = "*bold* _italic_ ``` &amp;"
+        missing = check_markers(text)
+        assert len(missing) > 0
+        assert all(m not in text for m in missing)
+
+    def test_empty_text_all_missing(self):
+        missing = check_markers("")
+        assert len(missing) == len(EXPECTED_MARKERS)
+
+    def test_returns_specific_missing_markers(self):
+        text = "*bold* _italic_ ~strike~ <@ <# <!here> @channel ``` &amp; &lt; &gt;"
+        missing = check_markers(text)
+        assert "<!date^" in missing
+        assert "*bold*" not in missing
+
+
+class TestSlackDocsParser:
+    def test_extracts_text(self):
+        parser = SlackDocsParser()
+        parser.feed("<html><body><p>Hello world</p></body></html>")
+        assert "Hello world" in parser.text_parts
+
+    def test_skips_script_tags(self):
+        parser = SlackDocsParser()
+        parser.feed("<html><script>var x = 1;</script><p>Visible</p></html>")
+        assert "Visible" in parser.text_parts
+        assert "var x = 1;" not in parser.text_parts
+
+    def test_skips_style_tags(self):
+        parser = SlackDocsParser()
+        parser.feed("<html><style>.foo{color:red}</style><p>Content</p></html>")
+        assert "Content" in parser.text_parts
+        assert ".foo" not in parser.text_parts
+
+    def test_skips_nav_and_footer(self):
+        parser = SlackDocsParser()
+        parser.feed("<nav>Navigation</nav><main>Main content</main><footer>Footer</footer>")
+        assert "Main content" in parser.text_parts
+        assert "Navigation" not in parser.text_parts
+        assert "Footer" not in parser.text_parts
+
+    def test_skips_empty_text(self):
+        parser = SlackDocsParser()
+        parser.feed("<p>   </p><p>Real content</p>")
+        assert "Real content" in parser.text_parts
+        assert len(parser.text_parts) == 1
+
+
+class TestExpectedMarkers:
+    def test_markers_list_not_empty(self):
+        assert len(EXPECTED_MARKERS) >= 10
+
+    def test_markers_cover_key_formatting(self):
+        markers_str = " ".join(EXPECTED_MARKERS)
+        assert "*bold*" in markers_str
+        assert "_italic_" in markers_str
+        assert "```" in markers_str
+        assert "<@" in markers_str
+        assert "<#" in markers_str


### PR DESCRIPTION
## Summary

- Add `get_formatting_guide` MCP tool that returns the Slack mrkdwn syntax reference from `formatting_guide.json`, so AI agents learn the correct formatting before composing messages instead of using standard Markdown
- Auto-resolve `@handle` and `#channel` references to Slack user/channel IDs in `post_message`, `send_dm`, and `send_group_dm` (on by default, opt-out via `resolve_references=False`). Uses existing cached lookups (`resolve_user_id` 24h cache, `_channel_cache`)
- Add `scripts/update_formatting_guide.py` — a build-time staleness checker that validates the guide against Slack's live docs via expected markers
- Update `Containerfile` to copy the guide and run the checker at build time (best-effort with `|| true` for hermetic builds)
- Add 44 unit tests covering all new functionality

### Motivation

AI agents composing Slack messages frequently use standard Markdown syntax which renders incorrectly in Slack (e.g. `**bold**` instead of `*bold*`, `[text](url)` instead of `<url|text>`, ` ```python ` renders "python" as code). The formatting guide gives agents the correct rules before composing, and the auto-resolution eliminates the most common mistake of writing `@username` as plain text instead of `<@USER_ID>`.

### New tool: `get_formatting_guide`

Returns a structured JSON reference with:
- `rules` — 12 supported mrkdwn formatting options with syntax and examples
- `mentions` — 6 mention types (user, channel, group, @here, @channel, @everyone)
- `escaping` — 3 characters requiring HTML entity escaping
- `unsupported` — 9 standard Markdown features that do NOT work in Slack

The `post_message`, `send_dm`, and `send_group_dm` docstrings now instruct agents to call `get_formatting_guide` first.

### Auto-resolution

All message-sending tools now auto-resolve `@handle` → `<@USER_ID>` and `#channel` → `<#CHANNEL_ID>` before posting. Lookups use existing cached infrastructure. Already-formatted references (`<@...>`, `<#...>`) are skipped. Failed lookups leave text unchanged.

## Test plan

- [x] 44 unit tests passing (`pytest tests/ -v`)
- [x] `formatting_guide.json` validates against live Slack docs (12/12 markers found)
- [x] Server syntax validates (`python3 -c "import ast; ast.parse(open('slack_mcp_server.py').read())"`)
- [ ] Manual test: post a message with `@handle` and verify it renders as a mention
- [ ] Manual test: call `get_formatting_guide` and verify the guide is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)