### PR TITLE
feat: add update_usergroup_members tool

### DIFF
--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -1083,6 +1083,45 @@ async def clear_usergroup(usergroup_id: str) -> bool:
 
 
 @_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
+async def update_usergroup_members(usergroup_id: str, user_ids: list[str]) -> bool:
+    """Set the members of a Slack usergroup, replacing the current membership entirely.
+
+    Args:
+        usergroup_id: The usergroup ID (S...) to update
+        user_ids: List of user IDs (U...) that should be the members. Must contain
+                  at least one user — use clear_usergroup to remove all members.
+
+    Returns:
+        True if the membership was updated successfully, False otherwise
+    """
+    _deny_if_read_only()
+
+    if not user_ids:
+        log("Error: user_ids list is empty — use clear_usergroup to remove all members")
+        return False
+
+    users_str = ",".join(user_ids)
+    user_mentions = ", ".join([f"<@{uid}>" for uid in user_ids])
+    await log_to_slack(f"Updating usergroup {usergroup_id} to {len(user_ids)} member(s): {user_mentions}")
+
+    url = f"{SLACK_API_BASE}/usergroups.users.update"
+    payload = {
+        "usergroup": usergroup_id,
+        "users": users_str,
+    }
+
+    data = await make_request(url, payload=payload)
+
+    if not data or not data.get("ok"):
+        error_msg = data.get("error", "Unknown error") if data else "No response from Slack API"
+        log(f"Error updating usergroup members: {error_msg}")
+        return False
+
+    log(f"Successfully updated usergroup {usergroup_id} to {len(user_ids)} member(s)")
+    return True
+
+
+@_register_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=True))
 async def send_dm(
     user_id: str,
     message: str,

--- a/tests/test_update_usergroup_members.py
+++ b/tests/test_update_usergroup_members.py
@@ -1,0 +1,76 @@
+"""Tests for update_usergroup_members."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import slack_mcp_server as sms
+
+
+@pytest.fixture(autouse=True)
+def _suppress_logging():
+    with patch.object(sms, "log_to_slack", new_callable=AsyncMock):
+        yield
+
+
+class TestUpdateUsergroupMembers:
+    @pytest.mark.asyncio
+    async def test_updates_single_member(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"ok": True}
+            result = await sms.update_usergroup_members("S123", ["U001"])
+            assert result is True
+            call_payload = mock_req.call_args[1].get("payload") or mock_req.call_args[0][1] if len(mock_req.call_args[0]) > 1 else None
+            if call_payload is None:
+                call_payload = mock_req.call_args.kwargs.get("payload", mock_req.call_args[0][1] if len(mock_req.call_args[0]) > 1 else {})
+            assert mock_req.called
+
+    @pytest.mark.asyncio
+    async def test_updates_multiple_members(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"ok": True}
+            result = await sms.update_usergroup_members("S123", ["U001", "U002", "U003"])
+            assert result is True
+            call_args = mock_req.call_args
+            payload = call_args.kwargs.get("payload") or call_args[0][1]
+            assert "U001,U002,U003" == payload["users"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_user_list(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            result = await sms.update_usergroup_members("S123", [])
+            assert result is False
+            mock_req.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_api_error(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"ok": False, "error": "invalid_auth"}
+            result = await sms.update_usergroup_members("S123", ["U001"])
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_no_response(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = None
+            result = await sms.update_usergroup_members("S123", ["U001"])
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_api_endpoint(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"ok": True}
+            await sms.update_usergroup_members("S456", ["U789"])
+            url = mock_req.call_args[0][0]
+            assert url.endswith("/usergroups.users.update")
+
+    @pytest.mark.asyncio
+    async def test_sends_usergroup_id_in_payload(self):
+        with patch.object(sms, "make_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"ok": True}
+            await sms.update_usergroup_members("SABC", ["U001"])
+            payload = mock_req.call_args.kwargs.get("payload") or mock_req.call_args[0][1]
+            assert payload["usergroup"] == "SABC"


### PR DESCRIPTION
## Summary

- Add `update_usergroup_members` tool that sets the members of a Slack usergroup, replacing the current membership entirely
- Complements the existing `clear_usergroup` tool — callers can now set specific members, not just clear them
- Rejects empty user lists with a message to use `clear_usergroup` instead
- Includes 7 unit tests

### Details

Uses the same `usergroups.users.update` API endpoint that `clear_usergroup` already calls, but with actual user IDs instead of a deleted-user workaround.

Parameters:
- `usergroup_id` (str) — the usergroup ID (`S...`)
- `user_ids` (list[str]) — user IDs (`U...`) to set as members (replaces current membership)

Registered as a mutating tool (`destructiveHint=True`), excluded in read-only mode.

## Test plan

- [x] 7 unit tests passing (`pytest tests/test_update_usergroup_members.py -v`)
- [ ] Manual test: update a usergroup and verify membership in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)